### PR TITLE
feat: Added string options to search and aggregate commands

### DIFF
--- a/core/lettucemod/src/main/java/com/redis/lettucemod/RedisModulesAsyncCommandsImpl.java
+++ b/core/lettucemod/src/main/java/com/redis/lettucemod/RedisModulesAsyncCommandsImpl.java
@@ -50,583 +50,585 @@ import io.lettuce.core.codec.RedisCodec;
 
 @SuppressWarnings("unchecked")
 public class RedisModulesAsyncCommandsImpl<K, V> extends RedisAsyncCommandsImpl<K, V>
-		implements RedisModulesAsyncCommands<K, V> {
-
-	private final TimeSeriesCommandBuilder<K, V> timeSeriesCommandBuilder;
-	private final SearchCommandBuilder<K, V> searchCommandBuilder;
-	private final BloomCommandBuilder<K, V> bloomCommandBuilder;
-
-	public RedisModulesAsyncCommandsImpl(StatefulRedisModulesConnection<K, V> connection, RedisCodec<K, V> codec) {
-		super(connection, codec);
-		this.timeSeriesCommandBuilder = new TimeSeriesCommandBuilder<>(codec);
-		this.searchCommandBuilder = new SearchCommandBuilder<>(codec);
-		this.bloomCommandBuilder = new BloomCommandBuilder<>(codec);
-	}
-
-	@Override
-	public StatefulRedisModulesConnection<K, V> getStatefulConnection() {
-		return (StatefulRedisModulesConnection<K, V>) super.getStatefulConnection();
-	}
-
-	@Override
-	public RedisFuture<String> tsCreate(K key, CreateOptions<K, V> options) {
-		return dispatch(timeSeriesCommandBuilder.create(key, options));
-	}
-
-	@Override
-	public RedisFuture<String> tsAlter(K key, AlterOptions<K, V> options) {
-		return dispatch(timeSeriesCommandBuilder.alter(key, options));
-	}
-
-	@Override
-	public RedisFuture<Long> tsAdd(K key, Sample sample) {
-		return dispatch(timeSeriesCommandBuilder.add(key, sample));
-	}
-
-	@Override
-	public RedisFuture<Long> tsAdd(K key, Sample sample, AddOptions<K, V> options) {
-		return dispatch(timeSeriesCommandBuilder.add(key, sample, options));
-	}
-
-	@Override
-	public RedisFuture<Long> tsDecrby(K key, double value) {
-		return dispatch(timeSeriesCommandBuilder.decrby(key, value, null));
-	}
-
-	@Override
-	public RedisFuture<Long> tsDecrby(K key, double value, IncrbyOptions<K, V> options) {
-		return dispatch(timeSeriesCommandBuilder.decrby(key, value, options));
-	}
-
-	@Override
-	public RedisFuture<Long> tsIncrby(K key, double value) {
-		return dispatch(timeSeriesCommandBuilder.incrby(key, value, null));
-	}
-
-	@Override
-	public RedisFuture<Long> tsIncrby(K key, double value, IncrbyOptions<K, V> options) {
-		return dispatch(timeSeriesCommandBuilder.incrby(key, value, options));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> tsMadd(KeySample<K>... samples) {
-		return dispatch(timeSeriesCommandBuilder.madd(samples));
-	}
-
-	@Override
-	public RedisFuture<String> tsCreaterule(K sourceKey, K destKey, CreateRuleOptions options) {
-		return dispatch(timeSeriesCommandBuilder.createRule(sourceKey, destKey, options));
-	}
-
-	@Override
-	public RedisFuture<String> tsDeleterule(K sourceKey, K destKey) {
-		return dispatch(timeSeriesCommandBuilder.deleteRule(sourceKey, destKey));
-	}
-
-	@Override
-	public RedisFuture<List<Sample>> tsRange(K key, TimeRange range) {
-		return dispatch(timeSeriesCommandBuilder.range(key, range));
-	}
-
-	@Override
-	public RedisFuture<List<Sample>> tsRange(K key, TimeRange range, RangeOptions options) {
-		return dispatch(timeSeriesCommandBuilder.range(key, range, options));
-	}
-
-	@Override
-	public RedisFuture<List<Sample>> tsRevrange(K key, TimeRange range) {
-		return dispatch(timeSeriesCommandBuilder.revrange(key, range));
-	}
-
-	@Override
-	public RedisFuture<List<Sample>> tsRevrange(K key, TimeRange range, RangeOptions options) {
-		return dispatch(timeSeriesCommandBuilder.revrange(key, range, options));
-	}
-
-	@Override
-	public RedisFuture<List<RangeResult<K, V>>> tsMrange(TimeRange range) {
-		return dispatch(timeSeriesCommandBuilder.mrange(range));
-	}
-
-	@Override
-	public RedisFuture<List<RangeResult<K, V>>> tsMrange(TimeRange range, MRangeOptions<K, V> options) {
-		return dispatch(timeSeriesCommandBuilder.mrange(range, options));
-	}
-
-	@Override
-	public RedisFuture<List<RangeResult<K, V>>> tsMrevrange(TimeRange range) {
-		return dispatch(timeSeriesCommandBuilder.mrevrange(range));
-	}
-
-	@Override
-	public RedisFuture<List<RangeResult<K, V>>> tsMrevrange(TimeRange range, MRangeOptions<K, V> options) {
-		return dispatch(timeSeriesCommandBuilder.mrevrange(range, options));
-	}
-
-	@Override
-	public RedisFuture<Sample> tsGet(K key) {
-		return dispatch(timeSeriesCommandBuilder.get(key));
-	}
-
-	@Override
-	public RedisFuture<List<GetResult<K, V>>> tsMget(MGetOptions<K, V> options) {
-		return dispatch(timeSeriesCommandBuilder.mget(options));
-	}
-
-	@Override
-	public RedisFuture<List<GetResult<K, V>>> tsMget(V... filters) {
-		return dispatch(timeSeriesCommandBuilder.mget(filters));
-	}
-
-	@Override
-	public RedisFuture<List<GetResult<K, V>>> tsMgetWithLabels(V... filters) {
-		return dispatch(timeSeriesCommandBuilder.mgetWithLabels(filters));
-	}
-
-	@Override
-	public RedisFuture<List<Object>> tsInfo(K key) {
-		return dispatch(timeSeriesCommandBuilder.info(key, false));
-	}
-
-	@Override
-	public RedisFuture<List<Object>> tsInfoDebug(K key) {
-		return dispatch(timeSeriesCommandBuilder.info(key, true));
-	}
-
-	@Override
-	public RedisFuture<List<V>> tsQueryIndex(V... filters) {
-		return dispatch(timeSeriesCommandBuilder.queryIndex(filters));
-	}
-
-	@Override
-	public RedisFuture<Long> tsDel(K key, TimeRange timeRange) {
-		return dispatch(timeSeriesCommandBuilder.tsDel(key, timeRange));
-	}
-
-	@Override
-	public RedisFuture<String> ftCreate(K index, Field<K>... fields) {
-		return ftCreate(index, null, fields);
-	}
-
-	@Override
-	public RedisFuture<String> ftCreate(K index, com.redis.lettucemod.search.CreateOptions<K, V> options,
-			Field<K>... fields) {
-		return dispatch(searchCommandBuilder.create(index, options, fields));
-	}
-
-	@Override
-	public RedisFuture<String> ftDropindex(K index) {
-		return dispatch(searchCommandBuilder.dropIndex(index, false));
-	}
-
-	@Override
-	public RedisFuture<String> ftDropindexDeleteDocs(K index) {
-		return dispatch(searchCommandBuilder.dropIndex(index, true));
-	}
-
-	@Override
-	public RedisFuture<List<Object>> ftInfo(K index) {
-		return dispatch(searchCommandBuilder.info(index));
-	}
-
-	@Override
-	public RedisFuture<SearchResults<K, V>> ftSearch(K index, V query) {
-		return ftSearch(index, query, null);
-	}
-
-	@Override
-	public RedisFuture<SearchResults<K, V>> ftSearch(K index, V query, SearchOptions<K, V> options) {
-		return dispatch(searchCommandBuilder.search(index, query, options));
-	}
-
-	@Override
-	public RedisFuture<AggregateResults<K>> ftAggregate(K index, V query) {
-		return ftAggregate(index, query, (AggregateOptions<K, V>) null);
-	}
-
-	@Override
-	public RedisFuture<AggregateResults<K>> ftAggregate(K index, V query, AggregateOptions<K, V> options) {
-		return dispatch(searchCommandBuilder.aggregate(index, query, options));
-	}
-
-	@Override
-	public RedisFuture<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor) {
-		return ftAggregate(index, query, cursor, null);
-	}
-
-	@Override
-	public RedisFuture<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor,
-			AggregateOptions<K, V> options) {
-		return dispatch(searchCommandBuilder.aggregate(index, query, cursor, options));
-	}
-
-	@Override
-	public RedisFuture<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor) {
-		return dispatch(searchCommandBuilder.cursorRead(index, cursor, null));
-	}
-
-	@Override
-	public RedisFuture<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor, long count) {
-		return dispatch(searchCommandBuilder.cursorRead(index, cursor, count));
-	}
-
-	@Override
-	public RedisFuture<String> ftCursorDelete(K index, long cursor) {
-		return dispatch(searchCommandBuilder.cursorDelete(index, cursor));
-	}
-
-	@Override
-	public RedisFuture<Long> ftSugadd(K key, Suggestion<V> suggestion) {
-		return dispatch(searchCommandBuilder.sugadd(key, suggestion));
-	}
-
-	@Override
-	public RedisFuture<Long> ftSugaddIncr(K key, Suggestion<V> suggestion) {
-		return dispatch(searchCommandBuilder.sugaddIncr(key, suggestion));
-	}
-
-	@Override
-	public RedisFuture<List<Suggestion<V>>> ftSugget(K key, V prefix) {
-		return dispatch(searchCommandBuilder.sugget(key, prefix));
-	}
-
-	@Override
-	public RedisFuture<List<Suggestion<V>>> ftSugget(K key, V prefix, SuggetOptions options) {
-		return dispatch(searchCommandBuilder.sugget(key, prefix, options));
-	}
-
-	@Override
-	public RedisFuture<Boolean> ftSugdel(K key, V string) {
-		return dispatch(searchCommandBuilder.sugdel(key, string));
-	}
-
-	@Override
-	public RedisFuture<Long> ftSuglen(K key) {
-		return dispatch(searchCommandBuilder.suglen(key));
-	}
-
-	@Override
-	public RedisFuture<String> ftAlter(K index, Field<K> field) {
-		return dispatch(searchCommandBuilder.alter(index, field));
-	}
-
-	@Override
-	public RedisFuture<String> ftAliasadd(K name, K index) {
-		return dispatch(searchCommandBuilder.aliasAdd(name, index));
-	}
-
-	@Override
-	public RedisFuture<String> ftAliasdel(K name) {
-		return dispatch(searchCommandBuilder.aliasDel(name));
-	}
-
-	@Override
-	public RedisFuture<String> ftAliasupdate(K name, K index) {
-		return dispatch(searchCommandBuilder.aliasUpdate(name, index));
-	}
-
-	@Override
-	public RedisFuture<List<K>> ftList() {
-		return dispatch(searchCommandBuilder.list());
-	}
-
-	@Override
-	public RedisFuture<List<V>> ftTagvals(K index, K field) {
-		return dispatch(searchCommandBuilder.tagVals(index, field));
-	}
-
-	@Override
-	public RedisFuture<Long> ftDictadd(K dict, V... terms) {
-		return dispatch(searchCommandBuilder.dictadd(dict, terms));
-	}
-
-	@Override
-	public RedisFuture<Long> ftDictdel(K dict, V... terms) {
-		return dispatch(searchCommandBuilder.dictdel(dict, terms));
-	}
-
-	@Override
-	public RedisFuture<List<V>> ftDictdump(K dict) {
-		return dispatch(searchCommandBuilder.dictdump(dict));
-	}
-
-	@Override
-	public RedisFuture<Boolean> bfAdd(K key, V item) {
-		return dispatch(bloomCommandBuilder.bfAdd(key, item));
-	}
-
-	@Override
-	public RedisFuture<Long> bfCard(K key) {
-		return dispatch(bloomCommandBuilder.bfCard(key));
-	}
-
-	@Override
-	public RedisFuture<Boolean> bfExists(K key, V item) {
-		return dispatch(bloomCommandBuilder.bfExists(key, item));
-	}
-
-	@Override
-	public RedisFuture<BloomFilterInfo> bfInfo(K key) {
-		return dispatch(bloomCommandBuilder.bfInfo(key));
-	}
-
-	@Override
-	public RedisFuture<Long> bfInfo(K key, BloomFilterInfoType type) {
-		return dispatch(bloomCommandBuilder.bfInfo(key, type));
-	}
-
-	@Override
-	public RedisFuture<List<Boolean>> bfInsert(K key, V... items) {
-		return dispatch(bloomCommandBuilder.bfInsert(key, items));
-	}
-
-	@Override
-	public RedisFuture<List<Boolean>> bfInsert(K key, BloomFilterInsertOptions options, V... items) {
-		return dispatch(bloomCommandBuilder.bfInsert(key, options, items));
-	}
-
-	@Override
-	public RedisFuture<List<Boolean>> bfMAdd(K key, V... items) {
-		return dispatch(bloomCommandBuilder.bfMAdd(key, items));
-	}
-
-	@Override
-	public RedisFuture<List<Boolean>> bfMExists(K key, V... items) {
-		return dispatch(bloomCommandBuilder.bfMExists(key, items));
-	}
-
-	@Override
-	public RedisFuture<String> bfReserve(K key, double errorRate, long capacity) {
-		return bfReserve(key, errorRate, capacity, null);
-	}
-
-	@Override
-	public RedisFuture<String> bfReserve(K key, double errorRate, long capacity, BloomFilterReserveOptions options) {
-		return dispatch(bloomCommandBuilder.bfReserve(key, errorRate, capacity, options));
-	}
-
-	@Override
-	public RedisFuture<Boolean> cfAdd(K key, V item) {
-		return dispatch(bloomCommandBuilder.cfAdd(key, item));
-	}
-
-	@Override
-	public RedisFuture<Boolean> cfAddNx(K key, V item) {
-		return dispatch(bloomCommandBuilder.cfAddNx(key, item));
-	}
-
-	@Override
-	public RedisFuture<Long> cfCount(K key, V item) {
-		return dispatch(bloomCommandBuilder.cfCount(key, item));
-	}
-
-	@Override
-	public RedisFuture<Boolean> cfDel(K key, V item) {
-		return dispatch(bloomCommandBuilder.cfDel(key, item));
-	}
-
-	@Override
-	public RedisFuture<Boolean> cfExists(K key, V item) {
-		return dispatch(bloomCommandBuilder.cfExists(key, item));
-	}
-
-	@Override
-	public RedisFuture<CuckooFilter> cfInfo(K key) {
-		return dispatch(bloomCommandBuilder.cfInfo(key));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> cfInsert(K key, V... items) {
-		return dispatch(bloomCommandBuilder.cfInsert(key, items));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> cfInsert(K key, CuckooFilterInsertOptions options, V... items) {
-		return dispatch(bloomCommandBuilder.cfInsert(key, items, options));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> cfInsertNx(K key, V... items) {
-		return dispatch(bloomCommandBuilder.cfInsertNx(key, items));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> cfInsertNx(K key, CuckooFilterInsertOptions options, V... items) {
-		return dispatch(bloomCommandBuilder.cfInsertNx(key, items, options));
-	}
-
-	@Override
-	public RedisFuture<List<Boolean>> cfMExists(K key, V... items) {
-		return dispatch(bloomCommandBuilder.cfMExists(key, items));
-	}
-
-	@Override
-	public RedisFuture<String> cfReserve(K key, long capacity) {
-		return cfReserve(key, capacity, null);
-	}
-
-	@Override
-	public RedisFuture<String> cfReserve(K key, long capacity, CuckooFilterReserveOptions options) {
-		return dispatch(bloomCommandBuilder.cfReserve(key, capacity, options));
-	}
-
-	@Override
-	public RedisFuture<Long> cmsIncrBy(K key, V item, long increment) {
-		return dispatch(bloomCommandBuilder.cmsIncrBy(key, item, increment));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> cmsIncrBy(K key, LongScoredValue<V>... itemIncrements) {
-		return dispatch(bloomCommandBuilder.cmsIncrBy(key, itemIncrements));
-	}
-
-	@Override
-	public RedisFuture<String> cmsInitByProb(K key, double error, double probability) {
-		return dispatch(bloomCommandBuilder.cmsInitByProb(key, error, probability));
-	}
-
-	@Override
-	public RedisFuture<String> cmsInitByDim(K key, long width, long depth) {
-		return dispatch(bloomCommandBuilder.cmsInitByDim(key, width, depth));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> cmsQuery(K key, V... items) {
-		return dispatch(bloomCommandBuilder.cmsQuery(key, items));
-	}
-
-	@Override
-	public RedisFuture<String> cmsMerge(K destKey, K... keys) {
-		return dispatch(bloomCommandBuilder.cmsMerge(destKey, keys));
-	}
-
-	@Override
-	public RedisFuture<String> cmsMerge(K destKey, LongScoredValue<K>... sourceKeyWeights) {
-		return dispatch(bloomCommandBuilder.cmsMerge(destKey, sourceKeyWeights));
-	}
-
-	@Override
-	public RedisFuture<CmsInfo> cmsInfo(K key) {
-		return dispatch(bloomCommandBuilder.cmsInfo(key));
-	}
-
-	@Override
-	public RedisFuture<List<Value<V>>> topKAdd(K key, V... items) {
-		return dispatch(bloomCommandBuilder.topKAdd(key, items));
-	}
-
-	@Override
-	public RedisFuture<List<Value<V>>> topKIncrBy(K key, LongScoredValue<V>... itemIncrements) {
-		return dispatch(bloomCommandBuilder.topKIncrBy(key, itemIncrements));
-	}
-
-	@Override
-	public RedisFuture<TopKInfo> topKInfo(K key) {
-		return dispatch(bloomCommandBuilder.topKInfo(key));
-	}
-
-	@Override
-	public RedisFuture<List<String>> topKList(K key) {
-		return dispatch(bloomCommandBuilder.topKList(key));
-	}
-
-	@Override
-	public RedisFuture<List<KeyValue<String, Long>>> topKListWithScores(K key) {
-		return dispatch(bloomCommandBuilder.topKListWithScores(key));
-	}
-
-	@Override
-	public RedisFuture<List<Boolean>> topKQuery(K key, V... items) {
-		return dispatch(bloomCommandBuilder.topKQuery(key, items));
-	}
-
-	@Override
-	public RedisFuture<String> topKReserve(K key, long k) {
-		return dispatch(bloomCommandBuilder.topKReserve(key, k));
-	}
-
-	@Override
-	public RedisFuture<String> topKReserve(K key, long k, long width, long depth, double decay) {
-		return dispatch(bloomCommandBuilder.topKReserve(key, k, width, depth, decay));
-	}
-
-	@Override
-	public RedisFuture<String> tDigestAdd(K key, double... values) {
-		return dispatch(bloomCommandBuilder.tDigestAdd(key, values));
-	}
-
-	@Override
-	public RedisFuture<List<Double>> tDigestByRank(K key, long... ranks) {
-		return dispatch(bloomCommandBuilder.tDigestByRank(key, ranks));
-	}
-
-	@Override
-	public RedisFuture<List<Double>> tDigestByRevRank(K key, long... revRanks) {
-		return dispatch(bloomCommandBuilder.tDigestByRevRank(key, revRanks));
-	}
-
-	@Override
-	public RedisFuture<List<Double>> tDigestCdf(K key, double... values) {
-		return dispatch(bloomCommandBuilder.tDigestCdf(key, values));
-	}
-
-	@Override
-	public RedisFuture<String> tDigestCreate(K key) {
-		return dispatch(bloomCommandBuilder.tDigestCreate(key));
-	}
-
-	@Override
-	public RedisFuture<String> tDigestCreate(K key, long compression) {
-		return dispatch(bloomCommandBuilder.tDigestCreate(key, compression));
-	}
-
-	@Override
-	public RedisFuture<TDigestInfo> tDigestInfo(K key) {
-		return dispatch(bloomCommandBuilder.tDigestInfo(key));
-	}
-
-	@Override
-	public RedisFuture<Double> tDigestMax(K key) {
-		return dispatch(bloomCommandBuilder.tDigestMax(key));
-	}
-
-	@Override
-	public RedisFuture<String> tDigestMerge(K destinationKey, K... sourceKeys) {
-		return dispatch(bloomCommandBuilder.tDigestMerge(destinationKey, sourceKeys));
-	}
-
-	@Override
-	public RedisFuture<String> tDigestMerge(K destinationKey, TDigestMergeOptions options, K... sourceKeys) {
-		return dispatch(bloomCommandBuilder.tDigestMerge(destinationKey, options, sourceKeys));
-	}
-
-	@Override
-	public RedisFuture<Double> tDigestMin(K key) {
-		return dispatch(bloomCommandBuilder.tDigestMin(key));
-	}
-
-	@Override
-	public RedisFuture<List<Double>> tDigestQuantile(K key, double... quantiles) {
-		return dispatch(bloomCommandBuilder.tDigestQuantile(key, quantiles));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> tDigestRank(K key, double... values) {
-		return dispatch(bloomCommandBuilder.tDigestRank(key, values));
-	}
-
-	@Override
-	public RedisFuture<String> tDigestReset(K key) {
-		return dispatch(bloomCommandBuilder.tDigestReset(key));
-	}
-
-	@Override
-	public RedisFuture<List<Long>> tDigestRevRank(K key, double... values) {
-		return dispatch(bloomCommandBuilder.tDigestRevRank(key, values));
-	}
-
-	@Override
-	public RedisFuture<Double> tDigestTrimmedMean(K key, double lowCutQuantile, double highCutQuantile) {
-		return dispatch(bloomCommandBuilder.tDigestTrimmedMean(key, lowCutQuantile, highCutQuantile));
-	}
+        implements RedisModulesAsyncCommands<K, V> {
+
+    private final TimeSeriesCommandBuilder<K, V> timeSeriesCommandBuilder;
+
+    private final SearchCommandBuilder<K, V> searchCommandBuilder;
+
+    private final BloomCommandBuilder<K, V> bloomCommandBuilder;
+
+    public RedisModulesAsyncCommandsImpl(StatefulRedisModulesConnection<K, V> connection, RedisCodec<K, V> codec) {
+        super(connection, codec);
+        this.timeSeriesCommandBuilder = new TimeSeriesCommandBuilder<>(codec);
+        this.searchCommandBuilder = new SearchCommandBuilder<>(codec);
+        this.bloomCommandBuilder = new BloomCommandBuilder<>(codec);
+    }
+
+    @Override
+    public StatefulRedisModulesConnection<K, V> getStatefulConnection() {
+        return (StatefulRedisModulesConnection<K, V>) super.getStatefulConnection();
+    }
+
+    @Override
+    public RedisFuture<String> tsCreate(K key, CreateOptions<K, V> options) {
+        return dispatch(timeSeriesCommandBuilder.create(key, options));
+    }
+
+    @Override
+    public RedisFuture<String> tsAlter(K key, AlterOptions<K, V> options) {
+        return dispatch(timeSeriesCommandBuilder.alter(key, options));
+    }
+
+    @Override
+    public RedisFuture<Long> tsAdd(K key, Sample sample) {
+        return dispatch(timeSeriesCommandBuilder.add(key, sample));
+    }
+
+    @Override
+    public RedisFuture<Long> tsAdd(K key, Sample sample, AddOptions<K, V> options) {
+        return dispatch(timeSeriesCommandBuilder.add(key, sample, options));
+    }
+
+    @Override
+    public RedisFuture<Long> tsDecrby(K key, double value) {
+        return dispatch(timeSeriesCommandBuilder.decrby(key, value, null));
+    }
+
+    @Override
+    public RedisFuture<Long> tsDecrby(K key, double value, IncrbyOptions<K, V> options) {
+        return dispatch(timeSeriesCommandBuilder.decrby(key, value, options));
+    }
+
+    @Override
+    public RedisFuture<Long> tsIncrby(K key, double value) {
+        return dispatch(timeSeriesCommandBuilder.incrby(key, value, null));
+    }
+
+    @Override
+    public RedisFuture<Long> tsIncrby(K key, double value, IncrbyOptions<K, V> options) {
+        return dispatch(timeSeriesCommandBuilder.incrby(key, value, options));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> tsMadd(KeySample<K>... samples) {
+        return dispatch(timeSeriesCommandBuilder.madd(samples));
+    }
+
+    @Override
+    public RedisFuture<String> tsCreaterule(K sourceKey, K destKey, CreateRuleOptions options) {
+        return dispatch(timeSeriesCommandBuilder.createRule(sourceKey, destKey, options));
+    }
+
+    @Override
+    public RedisFuture<String> tsDeleterule(K sourceKey, K destKey) {
+        return dispatch(timeSeriesCommandBuilder.deleteRule(sourceKey, destKey));
+    }
+
+    @Override
+    public RedisFuture<List<Sample>> tsRange(K key, TimeRange range) {
+        return dispatch(timeSeriesCommandBuilder.range(key, range));
+    }
+
+    @Override
+    public RedisFuture<List<Sample>> tsRange(K key, TimeRange range, RangeOptions options) {
+        return dispatch(timeSeriesCommandBuilder.range(key, range, options));
+    }
+
+    @Override
+    public RedisFuture<List<Sample>> tsRevrange(K key, TimeRange range) {
+        return dispatch(timeSeriesCommandBuilder.revrange(key, range));
+    }
+
+    @Override
+    public RedisFuture<List<Sample>> tsRevrange(K key, TimeRange range, RangeOptions options) {
+        return dispatch(timeSeriesCommandBuilder.revrange(key, range, options));
+    }
+
+    @Override
+    public RedisFuture<List<RangeResult<K, V>>> tsMrange(TimeRange range) {
+        return dispatch(timeSeriesCommandBuilder.mrange(range));
+    }
+
+    @Override
+    public RedisFuture<List<RangeResult<K, V>>> tsMrange(TimeRange range, MRangeOptions<K, V> options) {
+        return dispatch(timeSeriesCommandBuilder.mrange(range, options));
+    }
+
+    @Override
+    public RedisFuture<List<RangeResult<K, V>>> tsMrevrange(TimeRange range) {
+        return dispatch(timeSeriesCommandBuilder.mrevrange(range));
+    }
+
+    @Override
+    public RedisFuture<List<RangeResult<K, V>>> tsMrevrange(TimeRange range, MRangeOptions<K, V> options) {
+        return dispatch(timeSeriesCommandBuilder.mrevrange(range, options));
+    }
+
+    @Override
+    public RedisFuture<Sample> tsGet(K key) {
+        return dispatch(timeSeriesCommandBuilder.get(key));
+    }
+
+    @Override
+    public RedisFuture<List<GetResult<K, V>>> tsMget(MGetOptions<K, V> options) {
+        return dispatch(timeSeriesCommandBuilder.mget(options));
+    }
+
+    @Override
+    public RedisFuture<List<GetResult<K, V>>> tsMget(V... filters) {
+        return dispatch(timeSeriesCommandBuilder.mget(filters));
+    }
+
+    @Override
+    public RedisFuture<List<GetResult<K, V>>> tsMgetWithLabels(V... filters) {
+        return dispatch(timeSeriesCommandBuilder.mgetWithLabels(filters));
+    }
+
+    @Override
+    public RedisFuture<List<Object>> tsInfo(K key) {
+        return dispatch(timeSeriesCommandBuilder.info(key, false));
+    }
+
+    @Override
+    public RedisFuture<List<Object>> tsInfoDebug(K key) {
+        return dispatch(timeSeriesCommandBuilder.info(key, true));
+    }
+
+    @Override
+    public RedisFuture<List<V>> tsQueryIndex(V... filters) {
+        return dispatch(timeSeriesCommandBuilder.queryIndex(filters));
+    }
+
+    @Override
+    public RedisFuture<Long> tsDel(K key, TimeRange timeRange) {
+        return dispatch(timeSeriesCommandBuilder.tsDel(key, timeRange));
+    }
+
+    @Override
+    public RedisFuture<String> ftCreate(K index, Field<K>... fields) {
+        return ftCreate(index, null, fields);
+    }
+
+    @Override
+    public RedisFuture<String> ftCreate(K index, com.redis.lettucemod.search.CreateOptions<K, V> options, Field<K>... fields) {
+        return dispatch(searchCommandBuilder.create(index, options, fields));
+    }
+
+    @Override
+    public RedisFuture<String> ftDropindex(K index) {
+        return dispatch(searchCommandBuilder.dropIndex(index, false));
+    }
+
+    @Override
+    public RedisFuture<String> ftDropindexDeleteDocs(K index) {
+        return dispatch(searchCommandBuilder.dropIndex(index, true));
+    }
+
+    @Override
+    public RedisFuture<List<Object>> ftInfo(K index) {
+        return dispatch(searchCommandBuilder.info(index));
+    }
+
+    @Override
+    public RedisFuture<SearchResults<K, V>> ftSearch(K index, V query, V... options) {
+        return dispatch(searchCommandBuilder.search(index, query, options));
+    }
+
+    @Override
+    public RedisFuture<SearchResults<K, V>> ftSearch(K index, V query, SearchOptions<K, V> options) {
+        return dispatch(searchCommandBuilder.search(index, query, options));
+    }
+
+    @Override
+    public RedisFuture<AggregateResults<K>> ftAggregate(K index, V query, V... options) {
+        return dispatch(searchCommandBuilder.aggregate(index, query, options));
+    }
+
+    @Override
+    public RedisFuture<AggregateResults<K>> ftAggregate(K index, V query, AggregateOptions<K, V> options) {
+        return dispatch(searchCommandBuilder.aggregate(index, query, options));
+    }
+
+    @Override
+    public RedisFuture<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor) {
+        return ftAggregate(index, query, cursor, null);
+    }
+
+    @Override
+    public RedisFuture<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor,
+            AggregateOptions<K, V> options) {
+        return dispatch(searchCommandBuilder.aggregate(index, query, cursor, options));
+    }
+
+    @Override
+    public RedisFuture<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor) {
+        return dispatch(searchCommandBuilder.cursorRead(index, cursor, null));
+    }
+
+    @Override
+    public RedisFuture<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor, long count) {
+        return dispatch(searchCommandBuilder.cursorRead(index, cursor, count));
+    }
+
+    @Override
+    public RedisFuture<String> ftCursorDelete(K index, long cursor) {
+        return dispatch(searchCommandBuilder.cursorDelete(index, cursor));
+    }
+
+    @Override
+    public RedisFuture<Long> ftSugadd(K key, Suggestion<V> suggestion) {
+        return dispatch(searchCommandBuilder.sugadd(key, suggestion));
+    }
+
+    @Override
+    public RedisFuture<Long> ftSugaddIncr(K key, Suggestion<V> suggestion) {
+        return dispatch(searchCommandBuilder.sugaddIncr(key, suggestion));
+    }
+
+    @Override
+    public RedisFuture<List<Suggestion<V>>> ftSugget(K key, V prefix) {
+        return dispatch(searchCommandBuilder.sugget(key, prefix));
+    }
+
+    @Override
+    public RedisFuture<List<Suggestion<V>>> ftSugget(K key, V prefix, SuggetOptions options) {
+        return dispatch(searchCommandBuilder.sugget(key, prefix, options));
+    }
+
+    @Override
+    public RedisFuture<Boolean> ftSugdel(K key, V string) {
+        return dispatch(searchCommandBuilder.sugdel(key, string));
+    }
+
+    @Override
+    public RedisFuture<Long> ftSuglen(K key) {
+        return dispatch(searchCommandBuilder.suglen(key));
+    }
+
+    @Override
+    public RedisFuture<String> ftAlter(K index, Field<K> field) {
+        return dispatch(searchCommandBuilder.alter(index, field));
+    }
+
+    @Override
+    public RedisFuture<String> ftAliasadd(K name, K index) {
+        return dispatch(searchCommandBuilder.aliasAdd(name, index));
+    }
+
+    @Override
+    public RedisFuture<String> ftAliasdel(K name) {
+        return dispatch(searchCommandBuilder.aliasDel(name));
+    }
+
+    @Override
+    public RedisFuture<String> ftAliasupdate(K name, K index) {
+        return dispatch(searchCommandBuilder.aliasUpdate(name, index));
+    }
+
+    @Override
+    public RedisFuture<List<K>> ftList() {
+        return dispatch(searchCommandBuilder.list());
+    }
+
+    @Override
+    public RedisFuture<List<V>> ftTagvals(K index, K field) {
+        return dispatch(searchCommandBuilder.tagVals(index, field));
+    }
+
+    @Override
+    public RedisFuture<Long> ftDictadd(K dict, V... terms) {
+        return dispatch(searchCommandBuilder.dictadd(dict, terms));
+    }
+
+    @Override
+    public RedisFuture<Long> ftDictdel(K dict, V... terms) {
+        return dispatch(searchCommandBuilder.dictdel(dict, terms));
+    }
+
+    @Override
+    public RedisFuture<List<V>> ftDictdump(K dict) {
+        return dispatch(searchCommandBuilder.dictdump(dict));
+    }
+
+    @Override
+    public RedisFuture<Boolean> bfAdd(K key, V item) {
+        return dispatch(bloomCommandBuilder.bfAdd(key, item));
+    }
+
+    @Override
+    public RedisFuture<Long> bfCard(K key) {
+        return dispatch(bloomCommandBuilder.bfCard(key));
+    }
+
+    @Override
+    public RedisFuture<Boolean> bfExists(K key, V item) {
+        return dispatch(bloomCommandBuilder.bfExists(key, item));
+    }
+
+    @Override
+    public RedisFuture<BloomFilterInfo> bfInfo(K key) {
+        return dispatch(bloomCommandBuilder.bfInfo(key));
+    }
+
+    @Override
+    public RedisFuture<Long> bfInfo(K key, BloomFilterInfoType type) {
+        return dispatch(bloomCommandBuilder.bfInfo(key, type));
+    }
+
+    @Override
+    public RedisFuture<List<Boolean>> bfInsert(K key, V... items) {
+        return dispatch(bloomCommandBuilder.bfInsert(key, items));
+    }
+
+    @Override
+    public RedisFuture<List<Boolean>> bfInsert(K key, BloomFilterInsertOptions options, V... items) {
+        return dispatch(bloomCommandBuilder.bfInsert(key, options, items));
+    }
+
+    @Override
+    public RedisFuture<List<Boolean>> bfMAdd(K key, V... items) {
+        return dispatch(bloomCommandBuilder.bfMAdd(key, items));
+    }
+
+    @Override
+    public RedisFuture<List<Boolean>> bfMExists(K key, V... items) {
+        return dispatch(bloomCommandBuilder.bfMExists(key, items));
+    }
+
+    @Override
+    public RedisFuture<String> bfReserve(K key, double errorRate, long capacity) {
+        return bfReserve(key, errorRate, capacity, null);
+    }
+
+    @Override
+    public RedisFuture<String> bfReserve(K key, double errorRate, long capacity, BloomFilterReserveOptions options) {
+        return dispatch(bloomCommandBuilder.bfReserve(key, errorRate, capacity, options));
+    }
+
+    @Override
+    public RedisFuture<Boolean> cfAdd(K key, V item) {
+        return dispatch(bloomCommandBuilder.cfAdd(key, item));
+    }
+
+    @Override
+    public RedisFuture<Boolean> cfAddNx(K key, V item) {
+        return dispatch(bloomCommandBuilder.cfAddNx(key, item));
+    }
+
+    @Override
+    public RedisFuture<Long> cfCount(K key, V item) {
+        return dispatch(bloomCommandBuilder.cfCount(key, item));
+    }
+
+    @Override
+    public RedisFuture<Boolean> cfDel(K key, V item) {
+        return dispatch(bloomCommandBuilder.cfDel(key, item));
+    }
+
+    @Override
+    public RedisFuture<Boolean> cfExists(K key, V item) {
+        return dispatch(bloomCommandBuilder.cfExists(key, item));
+    }
+
+    @Override
+    public RedisFuture<CuckooFilter> cfInfo(K key) {
+        return dispatch(bloomCommandBuilder.cfInfo(key));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> cfInsert(K key, V... items) {
+        return dispatch(bloomCommandBuilder.cfInsert(key, items));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> cfInsert(K key, CuckooFilterInsertOptions options, V... items) {
+        return dispatch(bloomCommandBuilder.cfInsert(key, items, options));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> cfInsertNx(K key, V... items) {
+        return dispatch(bloomCommandBuilder.cfInsertNx(key, items));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> cfInsertNx(K key, CuckooFilterInsertOptions options, V... items) {
+        return dispatch(bloomCommandBuilder.cfInsertNx(key, items, options));
+    }
+
+    @Override
+    public RedisFuture<List<Boolean>> cfMExists(K key, V... items) {
+        return dispatch(bloomCommandBuilder.cfMExists(key, items));
+    }
+
+    @Override
+    public RedisFuture<String> cfReserve(K key, long capacity) {
+        return cfReserve(key, capacity, null);
+    }
+
+    @Override
+    public RedisFuture<String> cfReserve(K key, long capacity, CuckooFilterReserveOptions options) {
+        return dispatch(bloomCommandBuilder.cfReserve(key, capacity, options));
+    }
+
+    @Override
+    public RedisFuture<Long> cmsIncrBy(K key, V item, long increment) {
+        return dispatch(bloomCommandBuilder.cmsIncrBy(key, item, increment));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> cmsIncrBy(K key, LongScoredValue<V>... itemIncrements) {
+        return dispatch(bloomCommandBuilder.cmsIncrBy(key, itemIncrements));
+    }
+
+    @Override
+    public RedisFuture<String> cmsInitByProb(K key, double error, double probability) {
+        return dispatch(bloomCommandBuilder.cmsInitByProb(key, error, probability));
+    }
+
+    @Override
+    public RedisFuture<String> cmsInitByDim(K key, long width, long depth) {
+        return dispatch(bloomCommandBuilder.cmsInitByDim(key, width, depth));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> cmsQuery(K key, V... items) {
+        return dispatch(bloomCommandBuilder.cmsQuery(key, items));
+    }
+
+    @Override
+    public RedisFuture<String> cmsMerge(K destKey, K... keys) {
+        return dispatch(bloomCommandBuilder.cmsMerge(destKey, keys));
+    }
+
+    @Override
+    public RedisFuture<String> cmsMerge(K destKey, LongScoredValue<K>... sourceKeyWeights) {
+        return dispatch(bloomCommandBuilder.cmsMerge(destKey, sourceKeyWeights));
+    }
+
+    @Override
+    public RedisFuture<CmsInfo> cmsInfo(K key) {
+        return dispatch(bloomCommandBuilder.cmsInfo(key));
+    }
+
+    @Override
+    public RedisFuture<List<Value<V>>> topKAdd(K key, V... items) {
+        return dispatch(bloomCommandBuilder.topKAdd(key, items));
+    }
+
+    @Override
+    public RedisFuture<List<Value<V>>> topKIncrBy(K key, LongScoredValue<V>... itemIncrements) {
+        return dispatch(bloomCommandBuilder.topKIncrBy(key, itemIncrements));
+    }
+
+    @Override
+    public RedisFuture<TopKInfo> topKInfo(K key) {
+        return dispatch(bloomCommandBuilder.topKInfo(key));
+    }
+
+    @Override
+    public RedisFuture<List<String>> topKList(K key) {
+        return dispatch(bloomCommandBuilder.topKList(key));
+    }
+
+    @Override
+    public RedisFuture<List<KeyValue<String, Long>>> topKListWithScores(K key) {
+        return dispatch(bloomCommandBuilder.topKListWithScores(key));
+    }
+
+    @Override
+    public RedisFuture<List<Boolean>> topKQuery(K key, V... items) {
+        return dispatch(bloomCommandBuilder.topKQuery(key, items));
+    }
+
+    @Override
+    public RedisFuture<String> topKReserve(K key, long k) {
+        return dispatch(bloomCommandBuilder.topKReserve(key, k));
+    }
+
+    @Override
+    public RedisFuture<String> topKReserve(K key, long k, long width, long depth, double decay) {
+        return dispatch(bloomCommandBuilder.topKReserve(key, k, width, depth, decay));
+    }
+
+    @Override
+    public RedisFuture<String> tDigestAdd(K key, double... values) {
+        return dispatch(bloomCommandBuilder.tDigestAdd(key, values));
+    }
+
+    @Override
+    public RedisFuture<List<Double>> tDigestByRank(K key, long... ranks) {
+        return dispatch(bloomCommandBuilder.tDigestByRank(key, ranks));
+    }
+
+    @Override
+    public RedisFuture<List<Double>> tDigestByRevRank(K key, long... revRanks) {
+        return dispatch(bloomCommandBuilder.tDigestByRevRank(key, revRanks));
+    }
+
+    @Override
+    public RedisFuture<List<Double>> tDigestCdf(K key, double... values) {
+        return dispatch(bloomCommandBuilder.tDigestCdf(key, values));
+    }
+
+    @Override
+    public RedisFuture<String> tDigestCreate(K key) {
+        return dispatch(bloomCommandBuilder.tDigestCreate(key));
+    }
+
+    @Override
+    public RedisFuture<String> tDigestCreate(K key, long compression) {
+        return dispatch(bloomCommandBuilder.tDigestCreate(key, compression));
+    }
+
+    @Override
+    public RedisFuture<TDigestInfo> tDigestInfo(K key) {
+        return dispatch(bloomCommandBuilder.tDigestInfo(key));
+    }
+
+    @Override
+    public RedisFuture<Double> tDigestMax(K key) {
+        return dispatch(bloomCommandBuilder.tDigestMax(key));
+    }
+
+    @Override
+    public RedisFuture<String> tDigestMerge(K destinationKey, K... sourceKeys) {
+        return dispatch(bloomCommandBuilder.tDigestMerge(destinationKey, sourceKeys));
+    }
+
+    @Override
+    public RedisFuture<String> tDigestMerge(K destinationKey, TDigestMergeOptions options, K... sourceKeys) {
+        return dispatch(bloomCommandBuilder.tDigestMerge(destinationKey, options, sourceKeys));
+    }
+
+    @Override
+    public RedisFuture<Double> tDigestMin(K key) {
+        return dispatch(bloomCommandBuilder.tDigestMin(key));
+    }
+
+    @Override
+    public RedisFuture<List<Double>> tDigestQuantile(K key, double... quantiles) {
+        return dispatch(bloomCommandBuilder.tDigestQuantile(key, quantiles));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> tDigestRank(K key, double... values) {
+        return dispatch(bloomCommandBuilder.tDigestRank(key, values));
+    }
+
+    @Override
+    public RedisFuture<String> tDigestReset(K key) {
+        return dispatch(bloomCommandBuilder.tDigestReset(key));
+    }
+
+    @Override
+    public RedisFuture<List<Long>> tDigestRevRank(K key, double... values) {
+        return dispatch(bloomCommandBuilder.tDigestRevRank(key, values));
+    }
+
+    @Override
+    public RedisFuture<Double> tDigestTrimmedMean(K key, double lowCutQuantile, double highCutQuantile) {
+        return dispatch(bloomCommandBuilder.tDigestTrimmedMean(key, lowCutQuantile, highCutQuantile));
+    }
+
 }

--- a/core/lettucemod/src/main/java/com/redis/lettucemod/RedisModulesReactiveCommandsImpl.java
+++ b/core/lettucemod/src/main/java/com/redis/lettucemod/RedisModulesReactiveCommandsImpl.java
@@ -49,584 +49,588 @@ import reactor.core.publisher.Mono;
 
 @SuppressWarnings("unchecked")
 public class RedisModulesReactiveCommandsImpl<K, V> extends RedisReactiveCommandsImpl<K, V>
-		implements RedisModulesReactiveCommands<K, V> {
-
-	private final StatefulRedisModulesConnection<K, V> connection;
-	private final TimeSeriesCommandBuilder<K, V> timeSeriesCommandBuilder;
-	private final SearchCommandBuilder<K, V> searchCommandBuilder;
-	private final BloomCommandBuilder<K, V> bloomCommandBuilder;
-
-	public RedisModulesReactiveCommandsImpl(StatefulRedisModulesConnection<K, V> connection, RedisCodec<K, V> codec) {
-		super(connection, codec);
-		this.connection = connection;
-		this.timeSeriesCommandBuilder = new TimeSeriesCommandBuilder<>(codec);
-		this.searchCommandBuilder = new SearchCommandBuilder<>(codec);
-		this.bloomCommandBuilder = new BloomCommandBuilder<>(codec);
-	}
-
-	@Override
-	public StatefulRedisModulesConnection<K, V> getStatefulConnection() {
-		return connection;
-	}
-
-	@Override
-	public Mono<String> tsCreate(K key, CreateOptions<K, V> options) {
-		return createMono(() -> timeSeriesCommandBuilder.create(key, options));
-	}
-
-	@Override
-	public Mono<String> tsAlter(K key, AlterOptions<K, V> options) {
-		return createMono(() -> timeSeriesCommandBuilder.alter(key, options));
-	}
-
-	@Override
-	public Mono<Long> tsAdd(K key, Sample sample) {
-		return createMono(() -> timeSeriesCommandBuilder.add(key, sample));
-	}
-
-	@Override
-	public Mono<Long> tsAdd(K key, Sample sample, AddOptions<K, V> options) {
-		return createMono(() -> timeSeriesCommandBuilder.add(key, sample, options));
-	}
-
-	@Override
-	public Mono<Long> tsIncrby(K key, double value) {
-		return createMono(() -> timeSeriesCommandBuilder.incrby(key, value, null));
-	}
-
-	@Override
-	public Mono<Long> tsIncrby(K key, double value, IncrbyOptions<K, V> options) {
-		return createMono(() -> timeSeriesCommandBuilder.incrby(key, value, options));
-	}
-
-	@Override
-	public Mono<Long> tsDecrby(K key, double value) {
-		return createMono(() -> timeSeriesCommandBuilder.decrby(key, value, null));
-	}
-
-	@Override
-	public Mono<Long> tsDecrby(K key, double value, IncrbyOptions<K, V> options) {
-		return createMono(() -> timeSeriesCommandBuilder.decrby(key, value, options));
-	}
-
-	@Override
-	public Flux<Long> tsMadd(KeySample<K>... samples) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.madd(samples));
-	}
-
-	@Override
-	public Mono<String> tsCreaterule(K sourceKey, K destKey, CreateRuleOptions options) {
-		return createMono(() -> timeSeriesCommandBuilder.createRule(sourceKey, destKey, options));
-	}
-
-	@Override
-	public Mono<String> tsDeleterule(K sourceKey, K destKey) {
-		return createMono(() -> timeSeriesCommandBuilder.deleteRule(sourceKey, destKey));
-	}
-
-	@Override
-	public Flux<Sample> tsRange(K key, TimeRange range) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.range(key, range));
-	}
-
-	@Override
-	public Flux<Sample> tsRange(K key, TimeRange range, RangeOptions options) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.range(key, range, options));
-	}
-
-	@Override
-	public Flux<Sample> tsRevrange(K key, TimeRange range) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.revrange(key, range));
-	}
-
-	@Override
-	public Flux<Sample> tsRevrange(K key, TimeRange range, RangeOptions options) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.revrange(key, range, options));
-	}
-
-	@Override
-	public Flux<RangeResult<K, V>> tsMrange(TimeRange range) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.mrange(range));
-	}
-
-	@Override
-	public Flux<RangeResult<K, V>> tsMrange(TimeRange range, MRangeOptions<K, V> options) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.mrange(range, options));
-	}
-
-	@Override
-	public Flux<RangeResult<K, V>> tsMrevrange(TimeRange range) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.mrevrange(range));
-	}
-
-	@Override
-	public Flux<RangeResult<K, V>> tsMrevrange(TimeRange range, MRangeOptions<K, V> options) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.mrevrange(range, options));
-	}
-
-	@Override
-	public Mono<Sample> tsGet(K key) {
-		return createMono(() -> timeSeriesCommandBuilder.get(key));
-	}
-
-	@Override
-	public Flux<GetResult<K, V>> tsMget(MGetOptions<K, V> options) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.mget(options));
-	}
-
-	@Override
-	public Flux<GetResult<K, V>> tsMget(V... filters) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.mget(filters));
-	}
-
-	@Override
-	public Flux<GetResult<K, V>> tsMgetWithLabels(V... filters) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.mgetWithLabels(filters));
-	}
-
-	@Override
-	public Flux<Object> tsInfo(K key) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.info(key, false));
-	}
-
-	@Override
-	public Flux<Object> tsInfoDebug(K key) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.info(key, true));
-	}
-
-	@Override
-	public Flux<V> tsQueryIndex(V... filters) {
-		return createDissolvingFlux(() -> timeSeriesCommandBuilder.queryIndex(filters));
-	}
-
-	@Override
-	public Mono<Long> tsDel(K key, TimeRange timeRange) {
-		return createMono(() -> timeSeriesCommandBuilder.tsDel(key, timeRange));
-	}
-
-	@Override
-	public Mono<String> ftCreate(K index, Field<K>... fields) {
-		return ftCreate(index, null, fields);
-	}
-
-	@Override
-	public Mono<String> ftCreate(K index, com.redis.lettucemod.search.CreateOptions<K, V> options, Field<K>... fields) {
-		return createMono(() -> searchCommandBuilder.create(index, options, fields));
-	}
-
-	@Override
-	public Mono<String> ftDropindex(K index) {
-		return createMono(() -> searchCommandBuilder.dropIndex(index, false));
-	}
-
-	@Override
-	public Mono<String> ftDropindexDeleteDocs(K index) {
-		return createMono(() -> searchCommandBuilder.dropIndex(index, true));
-	}
-
-	@Override
-	public Flux<Object> ftInfo(K index) {
-		return createDissolvingFlux(() -> searchCommandBuilder.info(index));
-	}
-
-	@Override
-	public Mono<SearchResults<K, V>> ftSearch(K index, V query) {
-		return createMono(() -> searchCommandBuilder.search(index, query, null));
-	}
-
-	@Override
-	public Mono<SearchResults<K, V>> ftSearch(K index, V query, SearchOptions<K, V> options) {
-		return createMono(() -> searchCommandBuilder.search(index, query, options));
-	}
-
-	@Override
-	public Mono<AggregateResults<K>> ftAggregate(K index, V query) {
-		return createMono(() -> searchCommandBuilder.aggregate(index, query, null));
-	}
-
-	@Override
-	public Mono<AggregateResults<K>> ftAggregate(K index, V query, AggregateOptions<K, V> options) {
-		return createMono(() -> searchCommandBuilder.aggregate(index, query, options));
-	}
-
-	@Override
-	public Mono<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor) {
-		return createMono(() -> searchCommandBuilder.aggregate(index, query, cursor, null));
-	}
-
-	@Override
-	public Mono<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor,
-			AggregateOptions<K, V> options) {
-		return createMono(() -> searchCommandBuilder.aggregate(index, query, cursor, options));
-	}
-
-	@Override
-	public Mono<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor) {
-		return createMono(() -> searchCommandBuilder.cursorRead(index, cursor, null));
-	}
-
-	@Override
-	public Mono<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor, long count) {
-		return createMono(() -> searchCommandBuilder.cursorRead(index, cursor, count));
-	}
-
-	@Override
-	public Mono<String> ftCursorDelete(K index, long cursor) {
-		return createMono(() -> searchCommandBuilder.cursorDelete(index, cursor));
-	}
-
-	@Override
-	public Mono<Long> ftSugadd(K key, Suggestion<V> suggestion) {
-		return createMono(() -> searchCommandBuilder.sugadd(key, suggestion));
-	}
-
-	@Override
-	public Mono<Long> ftSugaddIncr(K key, Suggestion<V> suggestion) {
-		return createMono(() -> searchCommandBuilder.sugaddIncr(key, suggestion));
-	}
-
-	@Override
-	public Flux<Suggestion<V>> ftSugget(K key, V prefix) {
-		return createDissolvingFlux(() -> searchCommandBuilder.sugget(key, prefix));
-	}
-
-	@Override
-	public Flux<Suggestion<V>> ftSugget(K key, V prefix, SuggetOptions options) {
-		return createDissolvingFlux(() -> searchCommandBuilder.sugget(key, prefix, options));
-	}
-
-	@Override
-	public Mono<Boolean> ftSugdel(K key, V string) {
-		return createMono(() -> searchCommandBuilder.sugdel(key, string));
-	}
-
-	@Override
-	public Mono<Long> ftSuglen(K key) {
-		return createMono(() -> searchCommandBuilder.suglen(key));
-	}
-
-	@Override
-	public Mono<String> ftAlter(K index, Field<K> field) {
-		return createMono(() -> searchCommandBuilder.alter(index, field));
-	}
-
-	@Override
-	public Mono<String> ftAliasadd(K name, K index) {
-		return createMono(() -> searchCommandBuilder.aliasAdd(name, index));
-	}
-
-	@Override
-	public Mono<String> ftAliasupdate(K name, K index) {
-		return createMono(() -> searchCommandBuilder.aliasUpdate(name, index));
-	}
-
-	@Override
-	public Mono<String> ftAliasdel(K name) {
-		return createMono(() -> searchCommandBuilder.aliasDel(name));
-	}
-
-	@Override
-	public Flux<K> ftList() {
-		return createDissolvingFlux(searchCommandBuilder::list);
-	}
-
-	@Override
-	public Flux<V> ftTagvals(K index, K field) {
-		return createDissolvingFlux(() -> searchCommandBuilder.tagVals(index, field));
-	}
-
-	@Override
-	public Mono<Long> ftDictadd(K dict, V... terms) {
-		return createMono(() -> searchCommandBuilder.dictadd(dict, terms));
-	}
-
-	@Override
-	public Mono<Long> ftDictdel(K dict, V... terms) {
-		return createMono(() -> searchCommandBuilder.dictdel(dict, terms));
-	}
-
-	@Override
-	public Flux<V> ftDictdump(K dict) {
-		return createDissolvingFlux(() -> searchCommandBuilder.dictdump(dict));
-	}
-
-	@Override
-	public Flux<Value<V>> topKAdd(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.topKAdd(key, items));
-	}
-
-	@Override
-	public Flux<Value<V>> topKIncrBy(K key, LongScoredValue<V>... itemIncrements) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.topKIncrBy(key, itemIncrements));
-	}
-
-	@Override
-	public Mono<TopKInfo> topKInfo(K key) {
-		return createMono(() -> bloomCommandBuilder.topKInfo(key));
-	}
-
-	@Override
-	public Flux<String> topKList(K key) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.topKList(key));
-	}
-
-	@Override
-	public Flux<KeyValue<String, Long>> topKListWithScores(K key) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.topKListWithScores(key));
-	}
-
-	@Override
-	public Flux<Boolean> topKQuery(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.topKQuery(key, items));
-	}
-
-	@Override
-	public Mono<String> topKReserve(K key, long k) {
-		return createMono(() -> bloomCommandBuilder.topKReserve(key, k));
-	}
-
-	@Override
-	public Mono<String> topKReserve(K key, long k, long width, long depth, double decay) {
-		return createMono(() -> bloomCommandBuilder.topKReserve(key, k, width, depth, decay));
-	}
-
-	@Override
-	public Mono<String> tDigestAdd(K key, double... values) {
-		return createMono(() -> bloomCommandBuilder.tDigestAdd(key, values));
-	}
-
-	@Override
-	public Flux<Double> tDigestByRank(K key, long... ranks) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.tDigestByRank(key, ranks));
-	}
-
-	@Override
-	public Flux<Double> tDigestByRevRank(K key, long... revRanks) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.tDigestByRevRank(key, revRanks));
-	}
-
-	@Override
-	public Flux<Double> tDigestCdf(K key, double... values) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.tDigestCdf(key, values));
-	}
-
-	@Override
-	public Mono<String> tDigestCreate(K key) {
-		return createMono(() -> bloomCommandBuilder.tDigestCreate(key));
-	}
-
-	@Override
-	public Mono<String> tDigestCreate(K key, long compression) {
-		return createMono(() -> bloomCommandBuilder.tDigestCreate(key, compression));
-	}
-
-	@Override
-	public Mono<TDigestInfo> tDigestInfo(K key) {
-		return createMono(() -> bloomCommandBuilder.tDigestInfo(key));
-	}
-
-	@Override
-	public Mono<Double> tDigestMax(K key) {
-		return createMono(() -> bloomCommandBuilder.tDigestMax(key));
-	}
-
-	@Override
-	public Mono<String> tDigestMerge(K destinationKey, K... sourceKeys) {
-		return createMono(() -> bloomCommandBuilder.tDigestMerge(destinationKey, sourceKeys));
-	}
-
-	@Override
-	public Mono<String> tDigestMerge(K destinationKey, TDigestMergeOptions options, K... sourceKeys) {
-		return createMono(() -> bloomCommandBuilder.tDigestMerge(destinationKey, options, sourceKeys));
-	}
-
-	@Override
-	public Mono<Double> tDigestMin(K key) {
-		return createMono(() -> bloomCommandBuilder.tDigestMin(key));
-	}
-
-	@Override
-	public Flux<Double> tDigestQuantile(K key, double... quantiles) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.tDigestQuantile(key, quantiles));
-	}
-
-	@Override
-	public Flux<Long> tDigestRank(K key, double... values) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.tDigestRank(key, values));
-	}
-
-	@Override
-	public Mono<String> tDigestReset(K key) {
-		return createMono(() -> bloomCommandBuilder.tDigestReset(key));
-	}
-
-	@Override
-	public Flux<Long> tDigestRevRank(K key, double... values) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.tDigestRevRank(key, values));
-	}
-
-	@Override
-	public Mono<Double> tDigestTrimmedMean(K key, double lowCutQuantile, double highCutQuantile) {
-		return createMono(() -> bloomCommandBuilder.tDigestTrimmedMean(key, lowCutQuantile, highCutQuantile));
-	}
-
-	@Override
-	public Mono<Boolean> bfAdd(K key, V item) {
-		return createMono(() -> bloomCommandBuilder.bfAdd(key, item));
-	}
-
-	@Override
-	public Mono<Long> bfCard(K key) {
-		return createMono(() -> bloomCommandBuilder.bfCard(key));
-	}
-
-	@Override
-	public Mono<Boolean> bfExists(K key, V item) {
-		return createMono(() -> bloomCommandBuilder.bfExists(key, item));
-	}
-
-	@Override
-	public Mono<BloomFilterInfo> bfInfo(K key) {
-		return createMono(() -> bloomCommandBuilder.bfInfo(key));
-	}
-
-	@Override
-	public Mono<Long> bfInfo(K key, BloomFilterInfoType infoType) {
-		return createMono(() -> bloomCommandBuilder.bfInfo(key, infoType));
-	}
-
-	@Override
-	public Flux<Boolean> bfInsert(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.bfInsert(key, items));
-	}
-
-	@Override
-	public Flux<Boolean> bfInsert(K key, BloomFilterInsertOptions options, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.bfInsert(key, options, items));
-	}
-
-	@Override
-	public Flux<Boolean> bfMAdd(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.bfMAdd(key, items));
-	}
-
-	@Override
-	public Flux<Boolean> bfMExists(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.bfMExists(key, items));
-	}
-
-	@Override
-	public Mono<String> bfReserve(K key, double errorRate, long capacity) {
-		return bfReserve(key, errorRate, capacity, null);
-	}
-
-	@Override
-	public Mono<String> bfReserve(K key, double errorRate, long capacity, BloomFilterReserveOptions options) {
-		return createMono(() -> bloomCommandBuilder.bfReserve(key, errorRate, capacity, options));
-	}
-
-	@Override
-	public Mono<Boolean> cfAdd(K key, V item) {
-		return createMono(() -> bloomCommandBuilder.cfAdd(key, item));
-	}
-
-	@Override
-	public Mono<Boolean> cfAddNx(K key, V item) {
-		return createMono(() -> bloomCommandBuilder.cfAddNx(key, item));
-	}
-
-	@Override
-	public Mono<Long> cfCount(K key, V item) {
-		return createMono(() -> bloomCommandBuilder.cfCount(key, item));
-	}
-
-	@Override
-	public Mono<Boolean> cfDel(K key, V item) {
-		return createMono(() -> bloomCommandBuilder.cfDel(key, item));
-	}
-
-	@Override
-	public Mono<Boolean> cfExists(K key, V item) {
-		return createMono(() -> bloomCommandBuilder.cfExists(key, item));
-	}
-
-	@Override
-	public Mono<CuckooFilter> cfInfo(K key) {
-		return createMono(() -> bloomCommandBuilder.cfInfo(key));
-	}
-
-	@Override
-	public Flux<Long> cfInsert(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.cfInsert(key, items));
-	}
-
-	@Override
-	public Flux<Long> cfInsert(K key, CuckooFilterInsertOptions options, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.cfInsert(key, items, options));
-	}
-
-	@Override
-	public Flux<Long> cfInsertNx(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.cfInsertNx(key, items));
-	}
-
-	@Override
-	public Flux<Long> cfInsertNx(K key, CuckooFilterInsertOptions options, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.cfInsertNx(key, items, options));
-	}
-
-	@Override
-	public Flux<Boolean> cfMExists(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.cfMExists(key, items));
-	}
-
-	@Override
-	public Mono<String> cfReserve(K key, long capacity) {
-		return cfReserve(key, capacity, null);
-	}
-
-	@Override
-	public Mono<String> cfReserve(K key, long capacity, CuckooFilterReserveOptions options) {
-		return createMono(() -> bloomCommandBuilder.cfReserve(key, capacity, options));
-	}
-
-	@Override
-	public Mono<Long> cmsIncrBy(K key, V item, long increment) {
-		return createMono(() -> bloomCommandBuilder.cmsIncrBy(key, item, increment));
-	}
-
-	@Override
-	public Flux<Long> cmsIncrBy(K key, LongScoredValue<V>... itemIncrements) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.cmsIncrBy(key, itemIncrements));
-	}
-
-	@Override
-	public Mono<String> cmsInitByProb(K key, double error, double probability) {
-		return createMono(() -> bloomCommandBuilder.cmsInitByProb(key, error, probability));
-	}
-
-	@Override
-	public Mono<String> cmsInitByDim(K key, long width, long depth) {
-		return createMono(() -> bloomCommandBuilder.cmsInitByDim(key, width, depth));
-	}
-
-	@Override
-	public Flux<Long> cmsQuery(K key, V... items) {
-		return createDissolvingFlux(() -> bloomCommandBuilder.cmsQuery(key, items));
-	}
-
-	@Override
-	public Mono<String> cmsMerge(K destKey, K... keys) {
-		return createMono(() -> bloomCommandBuilder.cmsMerge(destKey, keys));
-	}
-
-	@Override
-	public Mono<String> cmsMerge(K destKey, LongScoredValue<K>... sourceKeyWeights) {
-		return createMono(() -> bloomCommandBuilder.cmsMerge(destKey, sourceKeyWeights));
-	}
-
-	@Override
-	public Mono<CmsInfo> cmsInfo(K key) {
-		return createMono(() -> bloomCommandBuilder.cmsInfo(key));
-	}
+        implements RedisModulesReactiveCommands<K, V> {
+
+    private final StatefulRedisModulesConnection<K, V> connection;
+
+    private final TimeSeriesCommandBuilder<K, V> timeSeriesCommandBuilder;
+
+    private final SearchCommandBuilder<K, V> searchCommandBuilder;
+
+    private final BloomCommandBuilder<K, V> bloomCommandBuilder;
+
+    public RedisModulesReactiveCommandsImpl(StatefulRedisModulesConnection<K, V> connection, RedisCodec<K, V> codec) {
+        super(connection, codec);
+        this.connection = connection;
+        this.timeSeriesCommandBuilder = new TimeSeriesCommandBuilder<>(codec);
+        this.searchCommandBuilder = new SearchCommandBuilder<>(codec);
+        this.bloomCommandBuilder = new BloomCommandBuilder<>(codec);
+    }
+
+    @Override
+    public StatefulRedisModulesConnection<K, V> getStatefulConnection() {
+        return connection;
+    }
+
+    @Override
+    public Mono<String> tsCreate(K key, CreateOptions<K, V> options) {
+        return createMono(() -> timeSeriesCommandBuilder.create(key, options));
+    }
+
+    @Override
+    public Mono<String> tsAlter(K key, AlterOptions<K, V> options) {
+        return createMono(() -> timeSeriesCommandBuilder.alter(key, options));
+    }
+
+    @Override
+    public Mono<Long> tsAdd(K key, Sample sample) {
+        return createMono(() -> timeSeriesCommandBuilder.add(key, sample));
+    }
+
+    @Override
+    public Mono<Long> tsAdd(K key, Sample sample, AddOptions<K, V> options) {
+        return createMono(() -> timeSeriesCommandBuilder.add(key, sample, options));
+    }
+
+    @Override
+    public Mono<Long> tsIncrby(K key, double value) {
+        return createMono(() -> timeSeriesCommandBuilder.incrby(key, value, null));
+    }
+
+    @Override
+    public Mono<Long> tsIncrby(K key, double value, IncrbyOptions<K, V> options) {
+        return createMono(() -> timeSeriesCommandBuilder.incrby(key, value, options));
+    }
+
+    @Override
+    public Mono<Long> tsDecrby(K key, double value) {
+        return createMono(() -> timeSeriesCommandBuilder.decrby(key, value, null));
+    }
+
+    @Override
+    public Mono<Long> tsDecrby(K key, double value, IncrbyOptions<K, V> options) {
+        return createMono(() -> timeSeriesCommandBuilder.decrby(key, value, options));
+    }
+
+    @Override
+    public Flux<Long> tsMadd(KeySample<K>... samples) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.madd(samples));
+    }
+
+    @Override
+    public Mono<String> tsCreaterule(K sourceKey, K destKey, CreateRuleOptions options) {
+        return createMono(() -> timeSeriesCommandBuilder.createRule(sourceKey, destKey, options));
+    }
+
+    @Override
+    public Mono<String> tsDeleterule(K sourceKey, K destKey) {
+        return createMono(() -> timeSeriesCommandBuilder.deleteRule(sourceKey, destKey));
+    }
+
+    @Override
+    public Flux<Sample> tsRange(K key, TimeRange range) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.range(key, range));
+    }
+
+    @Override
+    public Flux<Sample> tsRange(K key, TimeRange range, RangeOptions options) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.range(key, range, options));
+    }
+
+    @Override
+    public Flux<Sample> tsRevrange(K key, TimeRange range) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.revrange(key, range));
+    }
+
+    @Override
+    public Flux<Sample> tsRevrange(K key, TimeRange range, RangeOptions options) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.revrange(key, range, options));
+    }
+
+    @Override
+    public Flux<RangeResult<K, V>> tsMrange(TimeRange range) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.mrange(range));
+    }
+
+    @Override
+    public Flux<RangeResult<K, V>> tsMrange(TimeRange range, MRangeOptions<K, V> options) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.mrange(range, options));
+    }
+
+    @Override
+    public Flux<RangeResult<K, V>> tsMrevrange(TimeRange range) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.mrevrange(range));
+    }
+
+    @Override
+    public Flux<RangeResult<K, V>> tsMrevrange(TimeRange range, MRangeOptions<K, V> options) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.mrevrange(range, options));
+    }
+
+    @Override
+    public Mono<Sample> tsGet(K key) {
+        return createMono(() -> timeSeriesCommandBuilder.get(key));
+    }
+
+    @Override
+    public Flux<GetResult<K, V>> tsMget(MGetOptions<K, V> options) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.mget(options));
+    }
+
+    @Override
+    public Flux<GetResult<K, V>> tsMget(V... filters) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.mget(filters));
+    }
+
+    @Override
+    public Flux<GetResult<K, V>> tsMgetWithLabels(V... filters) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.mgetWithLabels(filters));
+    }
+
+    @Override
+    public Flux<Object> tsInfo(K key) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.info(key, false));
+    }
+
+    @Override
+    public Flux<Object> tsInfoDebug(K key) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.info(key, true));
+    }
+
+    @Override
+    public Flux<V> tsQueryIndex(V... filters) {
+        return createDissolvingFlux(() -> timeSeriesCommandBuilder.queryIndex(filters));
+    }
+
+    @Override
+    public Mono<Long> tsDel(K key, TimeRange timeRange) {
+        return createMono(() -> timeSeriesCommandBuilder.tsDel(key, timeRange));
+    }
+
+    @Override
+    public Mono<String> ftCreate(K index, Field<K>... fields) {
+        return ftCreate(index, null, fields);
+    }
+
+    @Override
+    public Mono<String> ftCreate(K index, com.redis.lettucemod.search.CreateOptions<K, V> options, Field<K>... fields) {
+        return createMono(() -> searchCommandBuilder.create(index, options, fields));
+    }
+
+    @Override
+    public Mono<String> ftDropindex(K index) {
+        return createMono(() -> searchCommandBuilder.dropIndex(index, false));
+    }
+
+    @Override
+    public Mono<String> ftDropindexDeleteDocs(K index) {
+        return createMono(() -> searchCommandBuilder.dropIndex(index, true));
+    }
+
+    @Override
+    public Flux<Object> ftInfo(K index) {
+        return createDissolvingFlux(() -> searchCommandBuilder.info(index));
+    }
+
+    @Override
+    public Mono<SearchResults<K, V>> ftSearch(K index, V query, V... options) {
+        return createMono(() -> searchCommandBuilder.search(index, query, options));
+    }
+
+    @Override
+    public Mono<SearchResults<K, V>> ftSearch(K index, V query, SearchOptions<K, V> options) {
+        return createMono(() -> searchCommandBuilder.search(index, query, options));
+    }
+
+    @Override
+    public Mono<AggregateResults<K>> ftAggregate(K index, V query, V... options) {
+        return createMono(() -> searchCommandBuilder.aggregate(index, query, options));
+    }
+
+    @Override
+    public Mono<AggregateResults<K>> ftAggregate(K index, V query, AggregateOptions<K, V> options) {
+        return createMono(() -> searchCommandBuilder.aggregate(index, query, options));
+    }
+
+    @Override
+    public Mono<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor) {
+        return createMono(() -> searchCommandBuilder.aggregate(index, query, cursor, null));
+    }
+
+    @Override
+    public Mono<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor,
+            AggregateOptions<K, V> options) {
+        return createMono(() -> searchCommandBuilder.aggregate(index, query, cursor, options));
+    }
+
+    @Override
+    public Mono<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor) {
+        return createMono(() -> searchCommandBuilder.cursorRead(index, cursor, null));
+    }
+
+    @Override
+    public Mono<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor, long count) {
+        return createMono(() -> searchCommandBuilder.cursorRead(index, cursor, count));
+    }
+
+    @Override
+    public Mono<String> ftCursorDelete(K index, long cursor) {
+        return createMono(() -> searchCommandBuilder.cursorDelete(index, cursor));
+    }
+
+    @Override
+    public Mono<Long> ftSugadd(K key, Suggestion<V> suggestion) {
+        return createMono(() -> searchCommandBuilder.sugadd(key, suggestion));
+    }
+
+    @Override
+    public Mono<Long> ftSugaddIncr(K key, Suggestion<V> suggestion) {
+        return createMono(() -> searchCommandBuilder.sugaddIncr(key, suggestion));
+    }
+
+    @Override
+    public Flux<Suggestion<V>> ftSugget(K key, V prefix) {
+        return createDissolvingFlux(() -> searchCommandBuilder.sugget(key, prefix));
+    }
+
+    @Override
+    public Flux<Suggestion<V>> ftSugget(K key, V prefix, SuggetOptions options) {
+        return createDissolvingFlux(() -> searchCommandBuilder.sugget(key, prefix, options));
+    }
+
+    @Override
+    public Mono<Boolean> ftSugdel(K key, V string) {
+        return createMono(() -> searchCommandBuilder.sugdel(key, string));
+    }
+
+    @Override
+    public Mono<Long> ftSuglen(K key) {
+        return createMono(() -> searchCommandBuilder.suglen(key));
+    }
+
+    @Override
+    public Mono<String> ftAlter(K index, Field<K> field) {
+        return createMono(() -> searchCommandBuilder.alter(index, field));
+    }
+
+    @Override
+    public Mono<String> ftAliasadd(K name, K index) {
+        return createMono(() -> searchCommandBuilder.aliasAdd(name, index));
+    }
+
+    @Override
+    public Mono<String> ftAliasupdate(K name, K index) {
+        return createMono(() -> searchCommandBuilder.aliasUpdate(name, index));
+    }
+
+    @Override
+    public Mono<String> ftAliasdel(K name) {
+        return createMono(() -> searchCommandBuilder.aliasDel(name));
+    }
+
+    @Override
+    public Flux<K> ftList() {
+        return createDissolvingFlux(searchCommandBuilder::list);
+    }
+
+    @Override
+    public Flux<V> ftTagvals(K index, K field) {
+        return createDissolvingFlux(() -> searchCommandBuilder.tagVals(index, field));
+    }
+
+    @Override
+    public Mono<Long> ftDictadd(K dict, V... terms) {
+        return createMono(() -> searchCommandBuilder.dictadd(dict, terms));
+    }
+
+    @Override
+    public Mono<Long> ftDictdel(K dict, V... terms) {
+        return createMono(() -> searchCommandBuilder.dictdel(dict, terms));
+    }
+
+    @Override
+    public Flux<V> ftDictdump(K dict) {
+        return createDissolvingFlux(() -> searchCommandBuilder.dictdump(dict));
+    }
+
+    @Override
+    public Flux<Value<V>> topKAdd(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.topKAdd(key, items));
+    }
+
+    @Override
+    public Flux<Value<V>> topKIncrBy(K key, LongScoredValue<V>... itemIncrements) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.topKIncrBy(key, itemIncrements));
+    }
+
+    @Override
+    public Mono<TopKInfo> topKInfo(K key) {
+        return createMono(() -> bloomCommandBuilder.topKInfo(key));
+    }
+
+    @Override
+    public Flux<String> topKList(K key) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.topKList(key));
+    }
+
+    @Override
+    public Flux<KeyValue<String, Long>> topKListWithScores(K key) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.topKListWithScores(key));
+    }
+
+    @Override
+    public Flux<Boolean> topKQuery(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.topKQuery(key, items));
+    }
+
+    @Override
+    public Mono<String> topKReserve(K key, long k) {
+        return createMono(() -> bloomCommandBuilder.topKReserve(key, k));
+    }
+
+    @Override
+    public Mono<String> topKReserve(K key, long k, long width, long depth, double decay) {
+        return createMono(() -> bloomCommandBuilder.topKReserve(key, k, width, depth, decay));
+    }
+
+    @Override
+    public Mono<String> tDigestAdd(K key, double... values) {
+        return createMono(() -> bloomCommandBuilder.tDigestAdd(key, values));
+    }
+
+    @Override
+    public Flux<Double> tDigestByRank(K key, long... ranks) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.tDigestByRank(key, ranks));
+    }
+
+    @Override
+    public Flux<Double> tDigestByRevRank(K key, long... revRanks) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.tDigestByRevRank(key, revRanks));
+    }
+
+    @Override
+    public Flux<Double> tDigestCdf(K key, double... values) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.tDigestCdf(key, values));
+    }
+
+    @Override
+    public Mono<String> tDigestCreate(K key) {
+        return createMono(() -> bloomCommandBuilder.tDigestCreate(key));
+    }
+
+    @Override
+    public Mono<String> tDigestCreate(K key, long compression) {
+        return createMono(() -> bloomCommandBuilder.tDigestCreate(key, compression));
+    }
+
+    @Override
+    public Mono<TDigestInfo> tDigestInfo(K key) {
+        return createMono(() -> bloomCommandBuilder.tDigestInfo(key));
+    }
+
+    @Override
+    public Mono<Double> tDigestMax(K key) {
+        return createMono(() -> bloomCommandBuilder.tDigestMax(key));
+    }
+
+    @Override
+    public Mono<String> tDigestMerge(K destinationKey, K... sourceKeys) {
+        return createMono(() -> bloomCommandBuilder.tDigestMerge(destinationKey, sourceKeys));
+    }
+
+    @Override
+    public Mono<String> tDigestMerge(K destinationKey, TDigestMergeOptions options, K... sourceKeys) {
+        return createMono(() -> bloomCommandBuilder.tDigestMerge(destinationKey, options, sourceKeys));
+    }
+
+    @Override
+    public Mono<Double> tDigestMin(K key) {
+        return createMono(() -> bloomCommandBuilder.tDigestMin(key));
+    }
+
+    @Override
+    public Flux<Double> tDigestQuantile(K key, double... quantiles) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.tDigestQuantile(key, quantiles));
+    }
+
+    @Override
+    public Flux<Long> tDigestRank(K key, double... values) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.tDigestRank(key, values));
+    }
+
+    @Override
+    public Mono<String> tDigestReset(K key) {
+        return createMono(() -> bloomCommandBuilder.tDigestReset(key));
+    }
+
+    @Override
+    public Flux<Long> tDigestRevRank(K key, double... values) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.tDigestRevRank(key, values));
+    }
+
+    @Override
+    public Mono<Double> tDigestTrimmedMean(K key, double lowCutQuantile, double highCutQuantile) {
+        return createMono(() -> bloomCommandBuilder.tDigestTrimmedMean(key, lowCutQuantile, highCutQuantile));
+    }
+
+    @Override
+    public Mono<Boolean> bfAdd(K key, V item) {
+        return createMono(() -> bloomCommandBuilder.bfAdd(key, item));
+    }
+
+    @Override
+    public Mono<Long> bfCard(K key) {
+        return createMono(() -> bloomCommandBuilder.bfCard(key));
+    }
+
+    @Override
+    public Mono<Boolean> bfExists(K key, V item) {
+        return createMono(() -> bloomCommandBuilder.bfExists(key, item));
+    }
+
+    @Override
+    public Mono<BloomFilterInfo> bfInfo(K key) {
+        return createMono(() -> bloomCommandBuilder.bfInfo(key));
+    }
+
+    @Override
+    public Mono<Long> bfInfo(K key, BloomFilterInfoType infoType) {
+        return createMono(() -> bloomCommandBuilder.bfInfo(key, infoType));
+    }
+
+    @Override
+    public Flux<Boolean> bfInsert(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.bfInsert(key, items));
+    }
+
+    @Override
+    public Flux<Boolean> bfInsert(K key, BloomFilterInsertOptions options, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.bfInsert(key, options, items));
+    }
+
+    @Override
+    public Flux<Boolean> bfMAdd(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.bfMAdd(key, items));
+    }
+
+    @Override
+    public Flux<Boolean> bfMExists(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.bfMExists(key, items));
+    }
+
+    @Override
+    public Mono<String> bfReserve(K key, double errorRate, long capacity) {
+        return bfReserve(key, errorRate, capacity, null);
+    }
+
+    @Override
+    public Mono<String> bfReserve(K key, double errorRate, long capacity, BloomFilterReserveOptions options) {
+        return createMono(() -> bloomCommandBuilder.bfReserve(key, errorRate, capacity, options));
+    }
+
+    @Override
+    public Mono<Boolean> cfAdd(K key, V item) {
+        return createMono(() -> bloomCommandBuilder.cfAdd(key, item));
+    }
+
+    @Override
+    public Mono<Boolean> cfAddNx(K key, V item) {
+        return createMono(() -> bloomCommandBuilder.cfAddNx(key, item));
+    }
+
+    @Override
+    public Mono<Long> cfCount(K key, V item) {
+        return createMono(() -> bloomCommandBuilder.cfCount(key, item));
+    }
+
+    @Override
+    public Mono<Boolean> cfDel(K key, V item) {
+        return createMono(() -> bloomCommandBuilder.cfDel(key, item));
+    }
+
+    @Override
+    public Mono<Boolean> cfExists(K key, V item) {
+        return createMono(() -> bloomCommandBuilder.cfExists(key, item));
+    }
+
+    @Override
+    public Mono<CuckooFilter> cfInfo(K key) {
+        return createMono(() -> bloomCommandBuilder.cfInfo(key));
+    }
+
+    @Override
+    public Flux<Long> cfInsert(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.cfInsert(key, items));
+    }
+
+    @Override
+    public Flux<Long> cfInsert(K key, CuckooFilterInsertOptions options, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.cfInsert(key, items, options));
+    }
+
+    @Override
+    public Flux<Long> cfInsertNx(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.cfInsertNx(key, items));
+    }
+
+    @Override
+    public Flux<Long> cfInsertNx(K key, CuckooFilterInsertOptions options, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.cfInsertNx(key, items, options));
+    }
+
+    @Override
+    public Flux<Boolean> cfMExists(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.cfMExists(key, items));
+    }
+
+    @Override
+    public Mono<String> cfReserve(K key, long capacity) {
+        return cfReserve(key, capacity, null);
+    }
+
+    @Override
+    public Mono<String> cfReserve(K key, long capacity, CuckooFilterReserveOptions options) {
+        return createMono(() -> bloomCommandBuilder.cfReserve(key, capacity, options));
+    }
+
+    @Override
+    public Mono<Long> cmsIncrBy(K key, V item, long increment) {
+        return createMono(() -> bloomCommandBuilder.cmsIncrBy(key, item, increment));
+    }
+
+    @Override
+    public Flux<Long> cmsIncrBy(K key, LongScoredValue<V>... itemIncrements) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.cmsIncrBy(key, itemIncrements));
+    }
+
+    @Override
+    public Mono<String> cmsInitByProb(K key, double error, double probability) {
+        return createMono(() -> bloomCommandBuilder.cmsInitByProb(key, error, probability));
+    }
+
+    @Override
+    public Mono<String> cmsInitByDim(K key, long width, long depth) {
+        return createMono(() -> bloomCommandBuilder.cmsInitByDim(key, width, depth));
+    }
+
+    @Override
+    public Flux<Long> cmsQuery(K key, V... items) {
+        return createDissolvingFlux(() -> bloomCommandBuilder.cmsQuery(key, items));
+    }
+
+    @Override
+    public Mono<String> cmsMerge(K destKey, K... keys) {
+        return createMono(() -> bloomCommandBuilder.cmsMerge(destKey, keys));
+    }
+
+    @Override
+    public Mono<String> cmsMerge(K destKey, LongScoredValue<K>... sourceKeyWeights) {
+        return createMono(() -> bloomCommandBuilder.cmsMerge(destKey, sourceKeyWeights));
+    }
+
+    @Override
+    public Mono<CmsInfo> cmsInfo(K key) {
+        return createMono(() -> bloomCommandBuilder.cmsInfo(key));
+    }
+
 }

--- a/core/lettucemod/src/main/java/com/redis/lettucemod/api/async/RediSearchAsyncCommands.java
+++ b/core/lettucemod/src/main/java/com/redis/lettucemod/api/async/RediSearchAsyncCommands.java
@@ -30,11 +30,11 @@ public interface RediSearchAsyncCommands<K, V> {
 
 	RedisFuture<List<K>> ftList();
 
-	RedisFuture<SearchResults<K, V>> ftSearch(K index, V query);
+	RedisFuture<SearchResults<K, V>> ftSearch(K index, V query, V... options);
 
 	RedisFuture<SearchResults<K, V>> ftSearch(K index, V query, SearchOptions<K, V> options);
 
-	RedisFuture<AggregateResults<K>> ftAggregate(K index, V query);
+	RedisFuture<AggregateResults<K>> ftAggregate(K index, V query, V... options);
 
 	RedisFuture<AggregateResults<K>> ftAggregate(K index, V query, AggregateOptions<K, V> options);
 

--- a/core/lettucemod/src/main/java/com/redis/lettucemod/api/reactive/RediSearchReactiveCommands.java
+++ b/core/lettucemod/src/main/java/com/redis/lettucemod/api/reactive/RediSearchReactiveCommands.java
@@ -38,11 +38,11 @@ public interface RediSearchReactiveCommands<K, V> {
 
 	Flux<K> ftList();
 
-	Mono<SearchResults<K, V>> ftSearch(K index, V query);
+	Mono<SearchResults<K, V>> ftSearch(K index, V query, V... options);
 
 	Mono<SearchResults<K, V>> ftSearch(K index, V query, SearchOptions<K, V> options);
 
-	Mono<AggregateResults<K>> ftAggregate(K index, V query);
+	Mono<AggregateResults<K>> ftAggregate(K index, V query, V... options);
 
 	Mono<AggregateResults<K>> ftAggregate(K index, V query, AggregateOptions<K, V> options);
 

--- a/core/lettucemod/src/main/java/com/redis/lettucemod/api/sync/RediSearchCommands.java
+++ b/core/lettucemod/src/main/java/com/redis/lettucemod/api/sync/RediSearchCommands.java
@@ -32,11 +32,11 @@ public interface RediSearchCommands<K, V> {
 	 */
 	List<K> ftList();
 
-	SearchResults<K, V> ftSearch(K index, V query);
+	SearchResults<K, V> ftSearch(K index, V query, V... options);
 
 	SearchResults<K, V> ftSearch(K index, V query, SearchOptions<K, V> options);
 
-	AggregateResults<K> ftAggregate(K index, V query);
+	AggregateResults<K> ftAggregate(K index, V query, V... options);
 
 	AggregateResults<K> ftAggregate(K index, V query, AggregateOptions<K, V> options);
 

--- a/core/lettucemod/src/main/java/com/redis/lettucemod/cluster/RedisModulesAdvancedClusterAsyncCommandsImpl.java
+++ b/core/lettucemod/src/main/java/com/redis/lettucemod/cluster/RedisModulesAdvancedClusterAsyncCommandsImpl.java
@@ -134,8 +134,8 @@ public class RedisModulesAdvancedClusterAsyncCommandsImpl<K, V> extends RedisAdv
 	}
 
 	@Override
-	public RedisFuture<SearchResults<K, V>> ftSearch(K index, V query) {
-		return delegate.ftSearch(index, query);
+	public RedisFuture<SearchResults<K, V>> ftSearch(K index, V query, V... options) {
+		return delegate.ftSearch(index, query, options);
 	}
 
 	@Override
@@ -144,8 +144,8 @@ public class RedisModulesAdvancedClusterAsyncCommandsImpl<K, V> extends RedisAdv
 	}
 
 	@Override
-	public RedisFuture<AggregateResults<K>> ftAggregate(K index, V query) {
-		return delegate.ftAggregate(index, query);
+	public RedisFuture<AggregateResults<K>> ftAggregate(K index, V query, V... options) {
+		return delegate.ftAggregate(index, query, options);
 	}
 
 	@Override

--- a/core/lettucemod/src/main/java/com/redis/lettucemod/cluster/RedisModulesAdvancedClusterReactiveCommandsImpl.java
+++ b/core/lettucemod/src/main/java/com/redis/lettucemod/cluster/RedisModulesAdvancedClusterReactiveCommandsImpl.java
@@ -51,608 +51,609 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @SuppressWarnings("unchecked")
-public class RedisModulesAdvancedClusterReactiveCommandsImpl<K, V> extends
-		RedisAdvancedClusterReactiveCommandsImpl<K, V> implements RedisModulesAdvancedClusterReactiveCommands<K, V> {
-
-	private final RedisModulesReactiveCommandsImpl<K, V> delegate;
-
-	public RedisModulesAdvancedClusterReactiveCommandsImpl(StatefulRedisModulesClusterConnection<K, V> connection,
-			RedisCodec<K, V> codec) {
-		super(connection, codec);
-		this.delegate = new RedisModulesReactiveCommandsImpl<>(connection, codec);
-	}
-
-	@Override
-	public RedisModulesAdvancedClusterReactiveCommands<K, V> getConnection(String nodeId) {
-		return (RedisModulesAdvancedClusterReactiveCommands<K, V>) super.getConnection(nodeId);
-	}
-
-	@Override
-	public RedisModulesAdvancedClusterReactiveCommands<K, V> getConnection(String host, int port) {
-		return (RedisModulesAdvancedClusterReactiveCommands<K, V>) super.getConnection(host, port);
-	}
-
-	@Override
-	public StatefulRedisModulesClusterConnection<K, V> getStatefulConnection() {
-		return (StatefulRedisModulesClusterConnection<K, V>) super.getStatefulConnection();
-	}
-
-	@Override
-	public Mono<String> ftCreate(K index, Field<K>... fields) {
-		return ftCreate(index, null, fields);
-	}
-
-	@Override
-	public Mono<String> ftCreate(K index, com.redis.lettucemod.search.CreateOptions<K, V> options, Field<K>... fields) {
-		Map<String, Publisher<String>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftCreate(index, options, fields));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Mono<String> ftDropindex(K index) {
-		Map<String, Publisher<String>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftDropindex(index));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Mono<String> ftDropindexDeleteDocs(K index) {
-		Map<String, Publisher<String>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftDropindexDeleteDocs(index));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Mono<String> ftAlter(K index, Field<K> field) {
-		Map<String, Publisher<String>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftAlter(index, field));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Flux<Object> ftInfo(K index) {
-		return delegate.ftInfo(index);
-	}
-
-	@Override
-	public Mono<String> ftAliasadd(K name, K index) {
-		Map<String, Publisher<String>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftAliasadd(name, index));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Mono<String> ftAliasupdate(K name, K index) {
-		Map<String, Publisher<String>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftAliasupdate(name, index));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Mono<String> ftAliasdel(K name) {
-		Map<String, Publisher<String>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftAliasdel(name));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Flux<K> ftList() {
-		return delegate.ftList();
-	}
-
-	@Override
-	public Mono<SearchResults<K, V>> ftSearch(K index, V query) {
-		return delegate.ftSearch(index, query);
-	}
-
-	@Override
-	public Mono<SearchResults<K, V>> ftSearch(K index, V query, SearchOptions<K, V> options) {
-		return delegate.ftSearch(index, query, options);
-	}
-
-	@Override
-	public Mono<AggregateResults<K>> ftAggregate(K index, V query) {
-		return delegate.ftAggregate(index, query);
-	}
-
-	@Override
-	public Mono<AggregateResults<K>> ftAggregate(K index, V query, AggregateOptions<K, V> options) {
-		return delegate.ftAggregate(index, query, options);
-	}
-
-	@Override
-	public Mono<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor) {
-		return delegate.ftAggregate(index, query, cursor);
-	}
-
-	@Override
-	public Mono<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor,
-			AggregateOptions<K, V> options) {
-		return delegate.ftAggregate(index, query, cursor, options);
-	}
-
-	@Override
-	public Mono<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor) {
-		return delegate.ftCursorRead(index, cursor);
-	}
-
-	@Override
-	public Mono<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor, long count) {
-		return delegate.ftCursorRead(index, cursor, count);
-	}
-
-	@Override
-	public Mono<String> ftCursorDelete(K index, long cursor) {
-		return delegate.ftCursorDelete(index, cursor);
-	}
-
-	@Override
-	public Flux<V> ftTagvals(K index, K field) {
-		return delegate.ftTagvals(index, field);
-	}
-
-	@Override
-	public Mono<Long> ftSugadd(K key, Suggestion<V> suggestion) {
-		return delegate.ftSugadd(key, suggestion);
-	}
-
-	@Override
-	public Mono<Long> ftSugaddIncr(K key, Suggestion<V> suggestion) {
-		return delegate.ftSugaddIncr(key, suggestion);
-	}
-
-	@Override
-	public Flux<Suggestion<V>> ftSugget(K key, V prefix) {
-		return delegate.ftSugget(key, prefix);
-	}
-
-	@Override
-	public Flux<Suggestion<V>> ftSugget(K key, V prefix, SuggetOptions options) {
-		return delegate.ftSugget(key, prefix, options);
-	}
-
-	@Override
-	public Mono<Boolean> ftSugdel(K key, V string) {
-		return delegate.ftSugdel(key, string);
-	}
-
-	@Override
-	public Mono<Long> ftSuglen(K key) {
-		return delegate.ftSuglen(key);
-	}
-
-	@Override
-	public Mono<Long> ftDictadd(K dict, V... terms) {
-		Map<String, Publisher<Long>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftDictadd(dict, terms));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Mono<Long> ftDictdel(K dict, V... terms) {
-		Map<String, Publisher<Long>> publishers = executeOnUpstream(
-				commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftDictdel(dict, terms));
-		return Flux.merge(publishers.values()).last();
-	}
-
-	@Override
-	public Flux<V> ftDictdump(K dict) {
-		return delegate.ftDictdump(dict);
-	}
-
-	@Override
-	public Flux<Value<V>> topKAdd(K key, V... items) {
-		return delegate.topKAdd(key, items);
-	}
-
-	@Override
-	public Flux<Value<V>> topKIncrBy(K key, LongScoredValue<V>... itemIncrements) {
-		return delegate.topKIncrBy(key, itemIncrements);
-	}
-
-	@Override
-	public Mono<TopKInfo> topKInfo(K key) {
-		return delegate.topKInfo(key);
-	}
-
-	@Override
-	public Flux<String> topKList(K key) {
-		return delegate.topKList(key);
-	}
-
-	@Override
-	public Flux<KeyValue<String, Long>> topKListWithScores(K key) {
-		return delegate.topKListWithScores(key);
-	}
-
-	@Override
-	public Flux<Boolean> topKQuery(K key, V... items) {
-		return delegate.topKQuery(key, items);
-	}
-
-	@Override
-	public Mono<String> topKReserve(K key, long k) {
-		return delegate.topKReserve(key, k);
-	}
-
-	@Override
-	public Mono<String> topKReserve(K key, long k, long width, long depth, double decay) {
-		return delegate.topKReserve(key, k, width, depth, decay);
-	}
-
-	@Override
-	public Mono<String> tDigestAdd(K key, double... value) {
-		return delegate.tDigestAdd(key, value);
-	}
-
-	@Override
-	public Flux<Double> tDigestByRank(K key, long... ranks) {
-		return delegate.tDigestByRank(key, ranks);
-	}
-
-	@Override
-	public Flux<Double> tDigestByRevRank(K key, long... revRanks) {
-		return delegate.tDigestByRevRank(key, revRanks);
-	}
-
-	@Override
-	public Flux<Double> tDigestCdf(K key, double... values) {
-		return delegate.tDigestCdf(key, values);
-	}
-
-	@Override
-	public Mono<String> tDigestCreate(K key) {
-		return delegate.tDigestCreate(key);
-	}
-
-	@Override
-	public Mono<String> tDigestCreate(K key, long compression) {
-		return delegate.tDigestCreate(key, compression);
-	}
-
-	@Override
-	public Mono<TDigestInfo> tDigestInfo(K key) {
-		return delegate.tDigestInfo(key);
-	}
-
-	@Override
-	public Mono<Double> tDigestMax(K key) {
-		return delegate.tDigestMax(key);
-	}
-
-	@Override
-	public Mono<String> tDigestMerge(K destinationKey, K... sourceKeys) {
-		return delegate.tDigestMerge(destinationKey, sourceKeys);
-	}
-
-	@Override
-	public Mono<String> tDigestMerge(K destinationKey, TDigestMergeOptions options, K... sourceKeys) {
-		return delegate.tDigestMerge(destinationKey, options, sourceKeys);
-	}
-
-	@Override
-	public Mono<Double> tDigestMin(K key) {
-		return delegate.tDigestMin(key);
-	}
-
-	@Override
-	public Flux<Double> tDigestQuantile(K key, double... quantiles) {
-		return delegate.tDigestQuantile(key, quantiles);
-	}
-
-	@Override
-	public Flux<Long> tDigestRank(K key, double... values) {
-		return delegate.tDigestRank(key, values);
-	}
-
-	@Override
-	public Mono<String> tDigestReset(K key) {
-		return delegate.tDigestReset(key);
-	}
-
-	@Override
-	public Flux<Long> tDigestRevRank(K key, double... values) {
-		return delegate.tDigestRevRank(key, values);
-	}
-
-	@Override
-	public Mono<Double> tDigestTrimmedMean(K key, double lowCutQuantile, double highCutQuantile) {
-		return delegate.tDigestTrimmedMean(key, lowCutQuantile, highCutQuantile);
-	}
-
-	@Override
-	public Mono<String> tsCreate(K key, CreateOptions<K, V> options) {
-		return delegate.tsCreate(key, options);
-	}
-
-	@Override
-	public Mono<String> tsAlter(K key, AlterOptions<K, V> options) {
-		return delegate.tsAlter(key, options);
-	}
-
-	@Override
-	public Mono<Long> tsAdd(K key, Sample sample) {
-		return delegate.tsAdd(key, sample);
-	}
-
-	@Override
-	public Mono<Long> tsAdd(K key, Sample sample, AddOptions<K, V> options) {
-		return delegate.tsAdd(key, sample, options);
-	}
-
-	@Override
-	public Flux<Long> tsMadd(KeySample<K>... samples) {
-		return delegate.tsMadd(samples);
-	}
-
-	@Override
-	public Mono<Long> tsDecrby(K key, double value) {
-		return delegate.tsDecrby(key, value);
-	}
-
-	@Override
-	public Mono<Long> tsDecrby(K key, double value, IncrbyOptions<K, V> options) {
-		return delegate.tsDecrby(key, value, options);
-	}
-
-	@Override
-	public Mono<Long> tsIncrby(K key, double value) {
-		return delegate.tsIncrby(key, value);
-	}
-
-	@Override
-	public Mono<Long> tsIncrby(K key, double value, IncrbyOptions<K, V> options) {
-		return delegate.tsIncrby(key, value, options);
-	}
-
-	@Override
-	public Mono<String> tsCreaterule(K sourceKey, K destKey, CreateRuleOptions options) {
-		return delegate.tsCreaterule(sourceKey, destKey, options);
-	}
-
-	@Override
-	public Mono<String> tsDeleterule(K sourceKey, K destKey) {
-		return delegate.tsDeleterule(sourceKey, destKey);
-	}
-
-	@Override
-	public Flux<Sample> tsRange(K key, TimeRange range) {
-		return delegate.tsRange(key, range);
-	}
-
-	@Override
-	public Flux<Sample> tsRange(K key, TimeRange range, RangeOptions options) {
-		return delegate.tsRange(key, range, options);
-	}
-
-	@Override
-	public Flux<Sample> tsRevrange(K key, TimeRange range) {
-		return delegate.tsRevrange(key, range);
-	}
-
-	@Override
-	public Flux<Sample> tsRevrange(K key, TimeRange range, RangeOptions options) {
-		return delegate.tsRevrange(key, range, options);
-	}
-
-	@Override
-	public Flux<RangeResult<K, V>> tsMrange(TimeRange range) {
-		return delegate.tsMrange(range);
-	}
-
-	@Override
-	public Flux<RangeResult<K, V>> tsMrange(TimeRange range, MRangeOptions<K, V> options) {
-		return delegate.tsMrange(range, options);
-	}
-
-	@Override
-	public Flux<RangeResult<K, V>> tsMrevrange(TimeRange range) {
-		return delegate.tsMrevrange(range);
-	}
-
-	@Override
-	public Flux<RangeResult<K, V>> tsMrevrange(TimeRange range, MRangeOptions<K, V> options) {
-		return delegate.tsMrevrange(range, options);
-	}
-
-	@Override
-	public Mono<Sample> tsGet(K key) {
-		return delegate.tsGet(key);
-	}
-
-	@Override
-	public Flux<GetResult<K, V>> tsMget(MGetOptions<K, V> options) {
-		return delegate.tsMget(options);
-	}
-
-	@Override
-	public Flux<GetResult<K, V>> tsMget(V... filters) {
-		return delegate.tsMget(filters);
-	}
-
-	@Override
-	public Flux<GetResult<K, V>> tsMgetWithLabels(V... filters) {
-		return delegate.tsMgetWithLabels(filters);
-	}
-
-	@Override
-	public Flux<Object> tsInfo(K key) {
-		return delegate.tsInfo(key);
-	}
-
-	@Override
-	public Flux<Object> tsInfoDebug(K key) {
-		return delegate.tsInfoDebug(key);
-	}
-
-	@Override
-	public Flux<V> tsQueryIndex(V... filters) {
-		return delegate.tsQueryIndex(filters);
-	}
-
-	@Override
-	public Mono<Long> tsDel(K key, TimeRange timeRange) {
-		return delegate.tsDel(key, timeRange);
-	}
-
-	@Override
-	public Mono<Boolean> bfAdd(K key, V item) {
-		return delegate.bfAdd(key, item);
-	}
-
-	@Override
-	public Mono<Long> bfCard(K key) {
-		return delegate.bfCard(key);
-	}
-
-	@Override
-	public Mono<Boolean> bfExists(K key, V item) {
-		return delegate.bfExists(key, item);
-	}
-
-	@Override
-	public Mono<BloomFilterInfo> bfInfo(K key) {
-		return delegate.bfInfo(key);
-	}
-
-	@Override
-	public Mono<Long> bfInfo(K key, BloomFilterInfoType infoType) {
-		return delegate.bfInfo(key, infoType);
-	}
-
-	@Override
-	public Flux<Boolean> bfInsert(K key, V... items) {
-		return delegate.bfInsert(key, items);
-	}
-
-	@Override
-	public Flux<Boolean> bfInsert(K key, BloomFilterInsertOptions options, V... items) {
-		return delegate.bfInsert(key, options, items);
-	}
-
-	@Override
-	public Flux<Boolean> bfMAdd(K key, V... items) {
-		return delegate.bfMAdd(key, items);
-	}
-
-	@Override
-	public Flux<Boolean> bfMExists(K key, V... items) {
-		return delegate.bfMExists(key, items);
-	}
-
-	@Override
-	public Mono<String> bfReserve(K key, double errorRate, long capacity) {
-		return delegate.bfReserve(key, errorRate, capacity);
-	}
-
-	@Override
-	public Mono<String> bfReserve(K key, double errorRate, long capacity, BloomFilterReserveOptions options) {
-		return delegate.bfReserve(key, errorRate, capacity, options);
-	}
-
-	@Override
-	public Mono<Boolean> cfAdd(K key, V item) {
-		return delegate.cfAdd(key, item);
-	}
-
-	@Override
-	public Mono<Boolean> cfAddNx(K key, V item) {
-		return delegate.cfAddNx(key, item);
-	}
-
-	@Override
-	public Mono<Long> cfCount(K key, V item) {
-		return delegate.cfCount(key, item);
-	}
-
-	@Override
-	public Mono<Boolean> cfDel(K key, V item) {
-		return delegate.cfDel(key, item);
-	}
-
-	@Override
-	public Mono<Boolean> cfExists(K key, V item) {
-		return delegate.cfExists(key, item);
-	}
-
-	@Override
-	public Mono<CuckooFilter> cfInfo(K key) {
-		return delegate.cfInfo(key);
-	}
-
-	@Override
-	public Flux<Long> cfInsert(K key, V... items) {
-		return delegate.cfInsert(key, items);
-	}
-
-	@Override
-	public Flux<Long> cfInsert(K key, CuckooFilterInsertOptions options, V... items) {
-		return delegate.cfInsert(key, options, items);
-	}
-
-	@Override
-	public Flux<Long> cfInsertNx(K key, V... items) {
-		return delegate.cfInsertNx(key, items);
-	}
-
-	@Override
-	public Flux<Long> cfInsertNx(K key, CuckooFilterInsertOptions options, V... items) {
-		return delegate.cfInsertNx(key, options, items);
-	}
-
-	@Override
-	public Flux<Boolean> cfMExists(K key, V... items) {
-		return delegate.cfMExists(key, items);
-	}
-
-	@Override
-	public Mono<String> cfReserve(K key, long capacity) {
-		return delegate.cfReserve(key, capacity);
-	}
-
-	@Override
-	public Mono<String> cfReserve(K key, long capacity, CuckooFilterReserveOptions options) {
-		return delegate.cfReserve(key, capacity, options);
-	}
-
-	@Override
-	public Mono<Long> cmsIncrBy(K key, V item, long increment) {
-		return delegate.cmsIncrBy(key, item, increment);
-	}
-
-	@Override
-	public Flux<Long> cmsIncrBy(K key, LongScoredValue<V>... itemIncrements) {
-		return delegate.cmsIncrBy(key, itemIncrements);
-	}
-
-	@Override
-	public Mono<String> cmsInitByProb(K key, double error, double probability) {
-		return delegate.cmsInitByProb(key, error, probability);
-	}
-
-	@Override
-	public Mono<String> cmsInitByDim(K key, long width, long depth) {
-		return delegate.cmsInitByDim(key, width, depth);
-	}
-
-	@Override
-	public Flux<Long> cmsQuery(K key, V... items) {
-		return delegate.cmsQuery(key, items);
-	}
-
-	@Override
-	public Mono<String> cmsMerge(K destKey, K... keys) {
-		return delegate.cmsMerge(destKey, keys);
-	}
-
-	@Override
-	public Mono<String> cmsMerge(K destKey, LongScoredValue<K>... sourceKeyWeights) {
-		return delegate.cmsMerge(destKey, sourceKeyWeights);
-	}
-
-	@Override
-	public Mono<CmsInfo> cmsInfo(K key) {
-		return delegate.cmsInfo(key);
-	}
+public class RedisModulesAdvancedClusterReactiveCommandsImpl<K, V> extends RedisAdvancedClusterReactiveCommandsImpl<K, V>
+        implements RedisModulesAdvancedClusterReactiveCommands<K, V> {
+
+    private final RedisModulesReactiveCommandsImpl<K, V> delegate;
+
+    public RedisModulesAdvancedClusterReactiveCommandsImpl(StatefulRedisModulesClusterConnection<K, V> connection,
+            RedisCodec<K, V> codec) {
+        super(connection, codec);
+        this.delegate = new RedisModulesReactiveCommandsImpl<>(connection, codec);
+    }
+
+    @Override
+    public RedisModulesAdvancedClusterReactiveCommands<K, V> getConnection(String nodeId) {
+        return (RedisModulesAdvancedClusterReactiveCommands<K, V>) super.getConnection(nodeId);
+    }
+
+    @Override
+    public RedisModulesAdvancedClusterReactiveCommands<K, V> getConnection(String host, int port) {
+        return (RedisModulesAdvancedClusterReactiveCommands<K, V>) super.getConnection(host, port);
+    }
+
+    @Override
+    public StatefulRedisModulesClusterConnection<K, V> getStatefulConnection() {
+        return (StatefulRedisModulesClusterConnection<K, V>) super.getStatefulConnection();
+    }
+
+    @Override
+    public Mono<String> ftCreate(K index, Field<K>... fields) {
+        return ftCreate(index, null, fields);
+    }
+
+    @Override
+    public Mono<String> ftCreate(K index, com.redis.lettucemod.search.CreateOptions<K, V> options, Field<K>... fields) {
+        Map<String, Publisher<String>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftCreate(index, options, fields));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Mono<String> ftDropindex(K index) {
+        Map<String, Publisher<String>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftDropindex(index));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Mono<String> ftDropindexDeleteDocs(K index) {
+        Map<String, Publisher<String>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftDropindexDeleteDocs(index));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Mono<String> ftAlter(K index, Field<K> field) {
+        Map<String, Publisher<String>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftAlter(index, field));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Flux<Object> ftInfo(K index) {
+        return delegate.ftInfo(index);
+    }
+
+    @Override
+    public Mono<String> ftAliasadd(K name, K index) {
+        Map<String, Publisher<String>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftAliasadd(name, index));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Mono<String> ftAliasupdate(K name, K index) {
+        Map<String, Publisher<String>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftAliasupdate(name, index));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Mono<String> ftAliasdel(K name) {
+        Map<String, Publisher<String>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftAliasdel(name));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Flux<K> ftList() {
+        return delegate.ftList();
+    }
+
+    @Override
+    public Mono<SearchResults<K, V>> ftSearch(K index, V query, V... options) {
+        return delegate.ftSearch(index, query, options);
+    }
+
+    @Override
+    public Mono<SearchResults<K, V>> ftSearch(K index, V query, SearchOptions<K, V> options) {
+        return delegate.ftSearch(index, query, options);
+    }
+
+    @Override
+    public Mono<AggregateResults<K>> ftAggregate(K index, V query, V... options) {
+        return delegate.ftAggregate(index, query, options);
+    }
+
+    @Override
+    public Mono<AggregateResults<K>> ftAggregate(K index, V query, AggregateOptions<K, V> options) {
+        return delegate.ftAggregate(index, query, options);
+    }
+
+    @Override
+    public Mono<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor) {
+        return delegate.ftAggregate(index, query, cursor);
+    }
+
+    @Override
+    public Mono<AggregateWithCursorResults<K>> ftAggregate(K index, V query, CursorOptions cursor,
+            AggregateOptions<K, V> options) {
+        return delegate.ftAggregate(index, query, cursor, options);
+    }
+
+    @Override
+    public Mono<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor) {
+        return delegate.ftCursorRead(index, cursor);
+    }
+
+    @Override
+    public Mono<AggregateWithCursorResults<K>> ftCursorRead(K index, long cursor, long count) {
+        return delegate.ftCursorRead(index, cursor, count);
+    }
+
+    @Override
+    public Mono<String> ftCursorDelete(K index, long cursor) {
+        return delegate.ftCursorDelete(index, cursor);
+    }
+
+    @Override
+    public Flux<V> ftTagvals(K index, K field) {
+        return delegate.ftTagvals(index, field);
+    }
+
+    @Override
+    public Mono<Long> ftSugadd(K key, Suggestion<V> suggestion) {
+        return delegate.ftSugadd(key, suggestion);
+    }
+
+    @Override
+    public Mono<Long> ftSugaddIncr(K key, Suggestion<V> suggestion) {
+        return delegate.ftSugaddIncr(key, suggestion);
+    }
+
+    @Override
+    public Flux<Suggestion<V>> ftSugget(K key, V prefix) {
+        return delegate.ftSugget(key, prefix);
+    }
+
+    @Override
+    public Flux<Suggestion<V>> ftSugget(K key, V prefix, SuggetOptions options) {
+        return delegate.ftSugget(key, prefix, options);
+    }
+
+    @Override
+    public Mono<Boolean> ftSugdel(K key, V string) {
+        return delegate.ftSugdel(key, string);
+    }
+
+    @Override
+    public Mono<Long> ftSuglen(K key) {
+        return delegate.ftSuglen(key);
+    }
+
+    @Override
+    public Mono<Long> ftDictadd(K dict, V... terms) {
+        Map<String, Publisher<Long>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftDictadd(dict, terms));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Mono<Long> ftDictdel(K dict, V... terms) {
+        Map<String, Publisher<Long>> publishers = executeOnUpstream(
+                commands -> ((RedisModulesReactiveCommands<K, V>) commands).ftDictdel(dict, terms));
+        return Flux.merge(publishers.values()).last();
+    }
+
+    @Override
+    public Flux<V> ftDictdump(K dict) {
+        return delegate.ftDictdump(dict);
+    }
+
+    @Override
+    public Flux<Value<V>> topKAdd(K key, V... items) {
+        return delegate.topKAdd(key, items);
+    }
+
+    @Override
+    public Flux<Value<V>> topKIncrBy(K key, LongScoredValue<V>... itemIncrements) {
+        return delegate.topKIncrBy(key, itemIncrements);
+    }
+
+    @Override
+    public Mono<TopKInfo> topKInfo(K key) {
+        return delegate.topKInfo(key);
+    }
+
+    @Override
+    public Flux<String> topKList(K key) {
+        return delegate.topKList(key);
+    }
+
+    @Override
+    public Flux<KeyValue<String, Long>> topKListWithScores(K key) {
+        return delegate.topKListWithScores(key);
+    }
+
+    @Override
+    public Flux<Boolean> topKQuery(K key, V... items) {
+        return delegate.topKQuery(key, items);
+    }
+
+    @Override
+    public Mono<String> topKReserve(K key, long k) {
+        return delegate.topKReserve(key, k);
+    }
+
+    @Override
+    public Mono<String> topKReserve(K key, long k, long width, long depth, double decay) {
+        return delegate.topKReserve(key, k, width, depth, decay);
+    }
+
+    @Override
+    public Mono<String> tDigestAdd(K key, double... value) {
+        return delegate.tDigestAdd(key, value);
+    }
+
+    @Override
+    public Flux<Double> tDigestByRank(K key, long... ranks) {
+        return delegate.tDigestByRank(key, ranks);
+    }
+
+    @Override
+    public Flux<Double> tDigestByRevRank(K key, long... revRanks) {
+        return delegate.tDigestByRevRank(key, revRanks);
+    }
+
+    @Override
+    public Flux<Double> tDigestCdf(K key, double... values) {
+        return delegate.tDigestCdf(key, values);
+    }
+
+    @Override
+    public Mono<String> tDigestCreate(K key) {
+        return delegate.tDigestCreate(key);
+    }
+
+    @Override
+    public Mono<String> tDigestCreate(K key, long compression) {
+        return delegate.tDigestCreate(key, compression);
+    }
+
+    @Override
+    public Mono<TDigestInfo> tDigestInfo(K key) {
+        return delegate.tDigestInfo(key);
+    }
+
+    @Override
+    public Mono<Double> tDigestMax(K key) {
+        return delegate.tDigestMax(key);
+    }
+
+    @Override
+    public Mono<String> tDigestMerge(K destinationKey, K... sourceKeys) {
+        return delegate.tDigestMerge(destinationKey, sourceKeys);
+    }
+
+    @Override
+    public Mono<String> tDigestMerge(K destinationKey, TDigestMergeOptions options, K... sourceKeys) {
+        return delegate.tDigestMerge(destinationKey, options, sourceKeys);
+    }
+
+    @Override
+    public Mono<Double> tDigestMin(K key) {
+        return delegate.tDigestMin(key);
+    }
+
+    @Override
+    public Flux<Double> tDigestQuantile(K key, double... quantiles) {
+        return delegate.tDigestQuantile(key, quantiles);
+    }
+
+    @Override
+    public Flux<Long> tDigestRank(K key, double... values) {
+        return delegate.tDigestRank(key, values);
+    }
+
+    @Override
+    public Mono<String> tDigestReset(K key) {
+        return delegate.tDigestReset(key);
+    }
+
+    @Override
+    public Flux<Long> tDigestRevRank(K key, double... values) {
+        return delegate.tDigestRevRank(key, values);
+    }
+
+    @Override
+    public Mono<Double> tDigestTrimmedMean(K key, double lowCutQuantile, double highCutQuantile) {
+        return delegate.tDigestTrimmedMean(key, lowCutQuantile, highCutQuantile);
+    }
+
+    @Override
+    public Mono<String> tsCreate(K key, CreateOptions<K, V> options) {
+        return delegate.tsCreate(key, options);
+    }
+
+    @Override
+    public Mono<String> tsAlter(K key, AlterOptions<K, V> options) {
+        return delegate.tsAlter(key, options);
+    }
+
+    @Override
+    public Mono<Long> tsAdd(K key, Sample sample) {
+        return delegate.tsAdd(key, sample);
+    }
+
+    @Override
+    public Mono<Long> tsAdd(K key, Sample sample, AddOptions<K, V> options) {
+        return delegate.tsAdd(key, sample, options);
+    }
+
+    @Override
+    public Flux<Long> tsMadd(KeySample<K>... samples) {
+        return delegate.tsMadd(samples);
+    }
+
+    @Override
+    public Mono<Long> tsDecrby(K key, double value) {
+        return delegate.tsDecrby(key, value);
+    }
+
+    @Override
+    public Mono<Long> tsDecrby(K key, double value, IncrbyOptions<K, V> options) {
+        return delegate.tsDecrby(key, value, options);
+    }
+
+    @Override
+    public Mono<Long> tsIncrby(K key, double value) {
+        return delegate.tsIncrby(key, value);
+    }
+
+    @Override
+    public Mono<Long> tsIncrby(K key, double value, IncrbyOptions<K, V> options) {
+        return delegate.tsIncrby(key, value, options);
+    }
+
+    @Override
+    public Mono<String> tsCreaterule(K sourceKey, K destKey, CreateRuleOptions options) {
+        return delegate.tsCreaterule(sourceKey, destKey, options);
+    }
+
+    @Override
+    public Mono<String> tsDeleterule(K sourceKey, K destKey) {
+        return delegate.tsDeleterule(sourceKey, destKey);
+    }
+
+    @Override
+    public Flux<Sample> tsRange(K key, TimeRange range) {
+        return delegate.tsRange(key, range);
+    }
+
+    @Override
+    public Flux<Sample> tsRange(K key, TimeRange range, RangeOptions options) {
+        return delegate.tsRange(key, range, options);
+    }
+
+    @Override
+    public Flux<Sample> tsRevrange(K key, TimeRange range) {
+        return delegate.tsRevrange(key, range);
+    }
+
+    @Override
+    public Flux<Sample> tsRevrange(K key, TimeRange range, RangeOptions options) {
+        return delegate.tsRevrange(key, range, options);
+    }
+
+    @Override
+    public Flux<RangeResult<K, V>> tsMrange(TimeRange range) {
+        return delegate.tsMrange(range);
+    }
+
+    @Override
+    public Flux<RangeResult<K, V>> tsMrange(TimeRange range, MRangeOptions<K, V> options) {
+        return delegate.tsMrange(range, options);
+    }
+
+    @Override
+    public Flux<RangeResult<K, V>> tsMrevrange(TimeRange range) {
+        return delegate.tsMrevrange(range);
+    }
+
+    @Override
+    public Flux<RangeResult<K, V>> tsMrevrange(TimeRange range, MRangeOptions<K, V> options) {
+        return delegate.tsMrevrange(range, options);
+    }
+
+    @Override
+    public Mono<Sample> tsGet(K key) {
+        return delegate.tsGet(key);
+    }
+
+    @Override
+    public Flux<GetResult<K, V>> tsMget(MGetOptions<K, V> options) {
+        return delegate.tsMget(options);
+    }
+
+    @Override
+    public Flux<GetResult<K, V>> tsMget(V... filters) {
+        return delegate.tsMget(filters);
+    }
+
+    @Override
+    public Flux<GetResult<K, V>> tsMgetWithLabels(V... filters) {
+        return delegate.tsMgetWithLabels(filters);
+    }
+
+    @Override
+    public Flux<Object> tsInfo(K key) {
+        return delegate.tsInfo(key);
+    }
+
+    @Override
+    public Flux<Object> tsInfoDebug(K key) {
+        return delegate.tsInfoDebug(key);
+    }
+
+    @Override
+    public Flux<V> tsQueryIndex(V... filters) {
+        return delegate.tsQueryIndex(filters);
+    }
+
+    @Override
+    public Mono<Long> tsDel(K key, TimeRange timeRange) {
+        return delegate.tsDel(key, timeRange);
+    }
+
+    @Override
+    public Mono<Boolean> bfAdd(K key, V item) {
+        return delegate.bfAdd(key, item);
+    }
+
+    @Override
+    public Mono<Long> bfCard(K key) {
+        return delegate.bfCard(key);
+    }
+
+    @Override
+    public Mono<Boolean> bfExists(K key, V item) {
+        return delegate.bfExists(key, item);
+    }
+
+    @Override
+    public Mono<BloomFilterInfo> bfInfo(K key) {
+        return delegate.bfInfo(key);
+    }
+
+    @Override
+    public Mono<Long> bfInfo(K key, BloomFilterInfoType infoType) {
+        return delegate.bfInfo(key, infoType);
+    }
+
+    @Override
+    public Flux<Boolean> bfInsert(K key, V... items) {
+        return delegate.bfInsert(key, items);
+    }
+
+    @Override
+    public Flux<Boolean> bfInsert(K key, BloomFilterInsertOptions options, V... items) {
+        return delegate.bfInsert(key, options, items);
+    }
+
+    @Override
+    public Flux<Boolean> bfMAdd(K key, V... items) {
+        return delegate.bfMAdd(key, items);
+    }
+
+    @Override
+    public Flux<Boolean> bfMExists(K key, V... items) {
+        return delegate.bfMExists(key, items);
+    }
+
+    @Override
+    public Mono<String> bfReserve(K key, double errorRate, long capacity) {
+        return delegate.bfReserve(key, errorRate, capacity);
+    }
+
+    @Override
+    public Mono<String> bfReserve(K key, double errorRate, long capacity, BloomFilterReserveOptions options) {
+        return delegate.bfReserve(key, errorRate, capacity, options);
+    }
+
+    @Override
+    public Mono<Boolean> cfAdd(K key, V item) {
+        return delegate.cfAdd(key, item);
+    }
+
+    @Override
+    public Mono<Boolean> cfAddNx(K key, V item) {
+        return delegate.cfAddNx(key, item);
+    }
+
+    @Override
+    public Mono<Long> cfCount(K key, V item) {
+        return delegate.cfCount(key, item);
+    }
+
+    @Override
+    public Mono<Boolean> cfDel(K key, V item) {
+        return delegate.cfDel(key, item);
+    }
+
+    @Override
+    public Mono<Boolean> cfExists(K key, V item) {
+        return delegate.cfExists(key, item);
+    }
+
+    @Override
+    public Mono<CuckooFilter> cfInfo(K key) {
+        return delegate.cfInfo(key);
+    }
+
+    @Override
+    public Flux<Long> cfInsert(K key, V... items) {
+        return delegate.cfInsert(key, items);
+    }
+
+    @Override
+    public Flux<Long> cfInsert(K key, CuckooFilterInsertOptions options, V... items) {
+        return delegate.cfInsert(key, options, items);
+    }
+
+    @Override
+    public Flux<Long> cfInsertNx(K key, V... items) {
+        return delegate.cfInsertNx(key, items);
+    }
+
+    @Override
+    public Flux<Long> cfInsertNx(K key, CuckooFilterInsertOptions options, V... items) {
+        return delegate.cfInsertNx(key, options, items);
+    }
+
+    @Override
+    public Flux<Boolean> cfMExists(K key, V... items) {
+        return delegate.cfMExists(key, items);
+    }
+
+    @Override
+    public Mono<String> cfReserve(K key, long capacity) {
+        return delegate.cfReserve(key, capacity);
+    }
+
+    @Override
+    public Mono<String> cfReserve(K key, long capacity, CuckooFilterReserveOptions options) {
+        return delegate.cfReserve(key, capacity, options);
+    }
+
+    @Override
+    public Mono<Long> cmsIncrBy(K key, V item, long increment) {
+        return delegate.cmsIncrBy(key, item, increment);
+    }
+
+    @Override
+    public Flux<Long> cmsIncrBy(K key, LongScoredValue<V>... itemIncrements) {
+        return delegate.cmsIncrBy(key, itemIncrements);
+    }
+
+    @Override
+    public Mono<String> cmsInitByProb(K key, double error, double probability) {
+        return delegate.cmsInitByProb(key, error, probability);
+    }
+
+    @Override
+    public Mono<String> cmsInitByDim(K key, long width, long depth) {
+        return delegate.cmsInitByDim(key, width, depth);
+    }
+
+    @Override
+    public Flux<Long> cmsQuery(K key, V... items) {
+        return delegate.cmsQuery(key, items);
+    }
+
+    @Override
+    public Mono<String> cmsMerge(K destKey, K... keys) {
+        return delegate.cmsMerge(destKey, keys);
+    }
+
+    @Override
+    public Mono<String> cmsMerge(K destKey, LongScoredValue<K>... sourceKeyWeights) {
+        return delegate.cmsMerge(destKey, sourceKeyWeights);
+    }
+
+    @Override
+    public Mono<CmsInfo> cmsInfo(K key) {
+        return delegate.cmsInfo(key);
+    }
+
 }

--- a/core/lettucemod/src/main/java/com/redis/lettucemod/search/SearchCommandBuilder.java
+++ b/core/lettucemod/src/main/java/com/redis/lettucemod/search/SearchCommandBuilder.java
@@ -1,6 +1,10 @@
 package com.redis.lettucemod.search;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
 
 import com.redis.lettucemod.RedisModulesCommandBuilder;
 import com.redis.lettucemod.output.AggregateOutput;
@@ -12,6 +16,7 @@ import com.redis.lettucemod.protocol.SearchCommandKeyword;
 import com.redis.lettucemod.protocol.SearchCommandType;
 
 import io.lettuce.core.codec.RedisCodec;
+import io.lettuce.core.codec.StringCodec;
 import io.lettuce.core.internal.LettuceAssert;
 import io.lettuce.core.output.BooleanOutput;
 import io.lettuce.core.output.CommandOutput;
@@ -28,265 +33,295 @@ import io.lettuce.core.protocol.CommandArgs;
  */
 public class SearchCommandBuilder<K, V> extends RedisModulesCommandBuilder<K, V> {
 
-	public SearchCommandBuilder(RedisCodec<K, V> codec) {
-		super(codec);
-	}
+    public SearchCommandBuilder(RedisCodec<K, V> codec) {
+        super(codec);
+    }
 
-	protected <A, B, T> Command<A, B, T> createCommand(SearchCommandType type, CommandOutput<A, B, T> output,
-			CommandArgs<A, B> args) {
-		return new Command<>(type, output, args);
-	}
+    protected <A, B, T> Command<A, B, T> createCommand(SearchCommandType type, CommandOutput<A, B, T> output,
+            CommandArgs<A, B> args) {
+        return new Command<>(type, output, args);
+    }
 
-	private static void notNullIndex(Object index) {
-		notNull(index, "Index");
-	}
+    private static void notNullIndex(Object index) {
+        notNull(index, "Index");
+    }
 
-	@SuppressWarnings("unchecked")
-	public Command<K, V, String> create(K index, CreateOptions<K, V> options, Field<K>... fields) {
-		notNullIndex(index);
-		LettuceAssert.isTrue(fields.length > 0, "At least one field is required.");
-		SearchCommandArgs<K, V> args = args(index);
-		if (options != null) {
-			options.build(args);
-		}
-		args.add(SearchCommandKeyword.SCHEMA);
-		for (Field<K> field : fields) {
-			field.build(args);
-		}
-		return createCommand(SearchCommandType.CREATE, new StatusOutput<>(codec), args);
-	}
+    @SuppressWarnings("unchecked")
+    public Command<K, V, String> create(K index, CreateOptions<K, V> options, Field<K>... fields) {
+        notNullIndex(index);
+        LettuceAssert.isTrue(fields.length > 0, "At least one field is required.");
+        SearchCommandArgs<K, V> args = args(index);
+        if (options != null) {
+            options.build(args);
+        }
+        args.add(SearchCommandKeyword.SCHEMA);
+        for (Field<K> field : fields) {
+            field.build(args);
+        }
+        return createCommand(SearchCommandType.CREATE, new StatusOutput<>(codec), args);
+    }
 
-	public Command<K, V, String> dropIndex(K index, boolean deleteDocs) {
-		notNullIndex(index);
-		SearchCommandArgs<K, V> args = args(index);
-		if (deleteDocs) {
-			args.add(SearchCommandKeyword.DD);
-		}
-		return createCommand(SearchCommandType.DROPINDEX, new StatusOutput<>(codec), args);
-	}
+    public Command<K, V, String> dropIndex(K index, boolean deleteDocs) {
+        notNullIndex(index);
+        SearchCommandArgs<K, V> args = args(index);
+        if (deleteDocs) {
+            args.add(SearchCommandKeyword.DD);
+        }
+        return createCommand(SearchCommandType.DROPINDEX, new StatusOutput<>(codec), args);
+    }
 
-	public Command<K, V, List<Object>> info(K index) {
-		notNullIndex(index);
-		SearchCommandArgs<K, V> args = args(index);
-		return createCommand(SearchCommandType.INFO, new NestedMultiOutput<>(codec), args);
-	}
+    public Command<K, V, List<Object>> info(K index) {
+        notNullIndex(index);
+        SearchCommandArgs<K, V> args = args(index);
+        return createCommand(SearchCommandType.INFO, new NestedMultiOutput<>(codec), args);
+    }
 
-	public Command<K, V, String> alter(K index, Field<K> field) {
-		notNullIndex(index);
-		notNull(field, "Field");
-		SearchCommandArgs<K, V> args = args(index);
-		args.add(SearchCommandKeyword.SCHEMA);
-		args.add(SearchCommandKeyword.ADD);
-		field.build(args);
-		return createCommand(SearchCommandType.ALTER, new StatusOutput<>(codec), args);
-	}
+    public Command<K, V, String> alter(K index, Field<K> field) {
+        notNullIndex(index);
+        notNull(field, "Field");
+        SearchCommandArgs<K, V> args = args(index);
+        args.add(SearchCommandKeyword.SCHEMA);
+        args.add(SearchCommandKeyword.ADD);
+        field.build(args);
+        return createCommand(SearchCommandType.ALTER, new StatusOutput<>(codec), args);
+    }
 
-	@Override
-	protected SearchCommandArgs<K, V> args(K key) {
-		return new SearchCommandArgs<>(codec).addKey(key);
-	}
+    @Override
+    protected SearchCommandArgs<K, V> args(K key) {
+        return new SearchCommandArgs<>(codec).addKey(key);
+    }
 
-	private static void notNullQuery(Object query) {
-		notNull(query, "Query");
-	}
+    private static void notNullQuery(Object query) {
+        notNull(query, "Query");
+    }
 
-	public Command<K, V, SearchResults<K, V>> search(K index, V query, SearchOptions<K, V> options) {
-		notNullIndex(index);
-		notNullQuery(query);
-		SearchCommandArgs<K, V> args = args(index);
-		args.addValue(query);
-		if (options != null) {
-			options.build(args);
-		}
-		return createCommand(SearchCommandType.SEARCH, searchOutput(options), args);
-	}
+    public Command<K, V, SearchResults<K, V>> search(K index, V query, SearchOptions<K, V> options) {
+        notNullIndex(index);
+        notNullQuery(query);
+        SearchCommandArgs<K, V> args = args(index);
+        args.addValue(query);
+        if (options != null) {
+            options.build(args);
+        }
+        return createCommand(SearchCommandType.SEARCH, searchOutput(options), args);
+    }
 
-	private CommandOutput<K, V, SearchResults<K, V>> searchOutput(SearchOptions<K, V> options) {
-		if (options == null) {
-			return new SearchOutput<>(codec);
-		}
-		if (options.isNoContent()) {
-			return new SearchNoContentOutput<>(codec, options.isWithScores());
-		}
-		return new SearchOutput<>(codec, options.isWithScores(), options.isWithSortKeys(), options.isWithPayloads());
-	}
+    private CommandOutput<K, V, SearchResults<K, V>> searchOutput(SearchOptions<K, V> options) {
+        if (options == null) {
+            return new SearchOutput<>(codec);
+        }
+        if (options.isNoContent()) {
+            return new SearchNoContentOutput<>(codec, options.isWithScores());
+        }
+        return new SearchOutput<>(codec, options.isWithScores(), options.isWithSortKeys(), options.isWithPayloads());
+    }
 
-	public Command<K, V, AggregateResults<K>> aggregate(K index, V query, AggregateOptions<K, V> options) {
-		notNullIndex(index);
-		notNullQuery(query);
-		SearchCommandArgs<K, V> args = args(index);
-		args.addValue(query);
-		if (options != null) {
-			options.build(args);
-		}
-		return createCommand(SearchCommandType.AGGREGATE, new AggregateOutput<>(codec, new AggregateResults<>()), args);
-	}
+    public Command<K, V, SearchResults<K, V>> search(K index, V query, V... options) {
+        notNullIndex(index);
+        notNullQuery(query);
+        SearchCommandArgs<K, V> args = args(index);
+        args.addValue(query);
+        SearchOptions<K, V> searchOptions = new SearchOptions<>();
+        args.addValues(options);
+        for (V option : options) {
+            String optionString = StringCodec.UTF8.decodeValue(codec.encodeValue(option));
+            if (SearchCommandKeyword.WITHSORTKEYS.name().equalsIgnoreCase(optionString)) {
+                searchOptions.setWithSortKeys(true);
+            }
+            if (SearchCommandKeyword.WITHPAYLOADS.name().equalsIgnoreCase(optionString)) {
+                searchOptions.setWithPayloads(true);
+            }
+            if (SearchCommandKeyword.WITHSCORES.name().equalsIgnoreCase(optionString)) {
+                searchOptions.setWithScores(true);
+            }
+        }
+        return createCommand(SearchCommandType.SEARCH, searchOutput(searchOptions), args);
+    }
 
-	public Command<K, V, AggregateWithCursorResults<K>> aggregate(K index, V query, CursorOptions cursor,
-			AggregateOptions<K, V> options) {
-		notNullIndex(index);
-		notNullQuery(query);
-		SearchCommandArgs<K, V> args = args(index);
-		args.addValue(query);
-		if (options != null) {
-			options.build(args);
-		}
-		args.add(SearchCommandKeyword.WITHCURSOR);
-		if (cursor != null) {
-			cursor.build(args);
-		}
-		return createCommand(SearchCommandType.AGGREGATE, new AggregateWithCursorOutput<>(codec), args);
-	}
+    public Command<K, V, AggregateResults<K>> aggregate(K index, V query, V... options) {
+        return doAggregate(index, query, args -> args.addValues(options));
+    }
 
-	public Command<K, V, AggregateWithCursorResults<K>> cursorRead(K index, long cursor, Long count) {
-		notNullIndex(index);
-		SearchCommandArgs<K, V> args = new SearchCommandArgs<>(codec);
-		args.add(SearchCommandKeyword.READ);
-		args.addKey(index);
-		args.add(cursor);
-		if (count != null) {
-			args.add(SearchCommandKeyword.COUNT);
-			args.add(count);
-		}
-		return createCommand(SearchCommandType.CURSOR, new AggregateWithCursorOutput<>(codec), args);
-	}
+    public Command<K, V, AggregateResults<K>> aggregate(K index, V query, AggregateOptions<K, V> options) {
+        return doAggregate(index, query, options == null ? null : options::build);
+    }
 
-	public Command<K, V, String> cursorDelete(K index, long cursor) {
-		notNullIndex(index);
-		SearchCommandArgs<K, V> args = new SearchCommandArgs<>(codec);
-		args.add(SearchCommandKeyword.DEL);
-		args.addKey(index);
-		args.add(cursor);
-		return createCommand(SearchCommandType.CURSOR, new StatusOutput<>(codec), args);
-	}
+    private Command<K, V, AggregateResults<K>> doAggregate(K index, V query, Consumer<SearchCommandArgs<K, V>> options) {
+        notNullIndex(index);
+        notNullQuery(query);
+        SearchCommandArgs<K, V> args = args(index);
+        args.addValue(query);
+        if (options != null) {
+            options.accept(args);
+        }
+        return createCommand(SearchCommandType.AGGREGATE, new AggregateOutput<>(codec, new AggregateResults<>()), args);
+    }
 
-	public Command<K, V, List<V>> tagVals(K index, K field) {
-		notNullIndex(index);
-		SearchCommandArgs<K, V> args = args(index);
-		args.addKey(field);
-		return createCommand(SearchCommandType.TAGVALS, new ValueListOutput<>(codec), args);
-	}
+    public Command<K, V, AggregateWithCursorResults<K>> aggregate(K index, V query, CursorOptions cursor,
+            AggregateOptions<K, V> options) {
+        notNullIndex(index);
+        notNullQuery(query);
+        SearchCommandArgs<K, V> args = args(index);
+        args.addValue(query);
+        if (options != null) {
+            options.build(args);
+        }
+        args.add(SearchCommandKeyword.WITHCURSOR);
+        if (cursor != null) {
+            cursor.build(args);
+        }
+        return createCommand(SearchCommandType.AGGREGATE, new AggregateWithCursorOutput<>(codec), args);
+    }
 
-	private static void notNullDict(Object dict) {
-		notNull(dict, "Dict");
-	}
+    public Command<K, V, AggregateWithCursorResults<K>> cursorRead(K index, long cursor, Long count) {
+        notNullIndex(index);
+        SearchCommandArgs<K, V> args = new SearchCommandArgs<>(codec);
+        args.add(SearchCommandKeyword.READ);
+        args.addKey(index);
+        args.add(cursor);
+        if (count != null) {
+            args.add(SearchCommandKeyword.COUNT);
+            args.add(count);
+        }
+        return createCommand(SearchCommandType.CURSOR, new AggregateWithCursorOutput<>(codec), args);
+    }
 
-	@SuppressWarnings("unchecked")
-	public Command<K, V, Long> dictadd(K dict, V... terms) {
-		notNullDict(dict);
-		return createCommand(SearchCommandType.DICTADD, new IntegerOutput<>(codec), args(dict).addValues(terms));
-	}
+    public Command<K, V, String> cursorDelete(K index, long cursor) {
+        notNullIndex(index);
+        SearchCommandArgs<K, V> args = new SearchCommandArgs<>(codec);
+        args.add(SearchCommandKeyword.DEL);
+        args.addKey(index);
+        args.add(cursor);
+        return createCommand(SearchCommandType.CURSOR, new StatusOutput<>(codec), args);
+    }
 
-	@SuppressWarnings("unchecked")
-	public Command<K, V, Long> dictdel(K dict, V... terms) {
-		notNullDict(dict);
-		return createCommand(SearchCommandType.DICTDEL, new IntegerOutput<>(codec), args(dict).addValues(terms));
-	}
+    public Command<K, V, List<V>> tagVals(K index, K field) {
+        notNullIndex(index);
+        SearchCommandArgs<K, V> args = args(index);
+        args.addKey(field);
+        return createCommand(SearchCommandType.TAGVALS, new ValueListOutput<>(codec), args);
+    }
 
-	public Command<K, V, List<V>> dictdump(K dict) {
-		notNullDict(dict);
-		return createCommand(SearchCommandType.DICTDUMP, new ValueListOutput<>(codec), args(dict));
-	}
+    private static void notNullDict(Object dict) {
+        notNull(dict, "Dict");
+    }
 
-	public Command<K, V, Long> sugadd(K key, V string, double score) {
-		return sugadd(key, string, score, null, false);
-	}
+    @SuppressWarnings("unchecked")
+    public Command<K, V, Long> dictadd(K dict, V... terms) {
+        notNullDict(dict);
+        return createCommand(SearchCommandType.DICTADD, new IntegerOutput<>(codec), args(dict).addValues(terms));
+    }
 
-	public Command<K, V, Long> sugaddIncr(K key, V string, double score) {
-		return sugadd(key, string, score, null, true);
-	}
+    @SuppressWarnings("unchecked")
+    public Command<K, V, Long> dictdel(K dict, V... terms) {
+        notNullDict(dict);
+        return createCommand(SearchCommandType.DICTDEL, new IntegerOutput<>(codec), args(dict).addValues(terms));
+    }
 
-	public Command<K, V, Long> sugadd(K key, V string, double score, V payload) {
-		return sugadd(key, string, score, payload, false);
-	}
+    public Command<K, V, List<V>> dictdump(K dict) {
+        notNullDict(dict);
+        return createCommand(SearchCommandType.DICTDUMP, new ValueListOutput<>(codec), args(dict));
+    }
 
-	public Command<K, V, Long> sugaddIncr(K key, V string, double score, V payload) {
-		return sugadd(key, string, score, payload, true);
-	}
+    public Command<K, V, Long> sugadd(K key, V string, double score) {
+        return sugadd(key, string, score, null, false);
+    }
 
-	public Command<K, V, Long> sugadd(K key, V string, double score, V payload, boolean increment) {
-		notNullKey(key);
-		notNull(string, "String");
-		SearchCommandArgs<K, V> args = args(key);
-		args.addValue(string);
-		args.add(score);
-		if (increment) {
-			args.add(SearchCommandKeyword.INCR);
-		}
-		if (payload != null) {
-			args.add(SearchCommandKeyword.PAYLOAD);
-			args.addValue(payload);
-		}
-		return createCommand(SearchCommandType.SUGADD, new IntegerOutput<>(codec), args);
-	}
+    public Command<K, V, Long> sugaddIncr(K key, V string, double score) {
+        return sugadd(key, string, score, null, true);
+    }
 
-	public Command<K, V, Long> sugadd(K key, Suggestion<V> suggestion) {
-		notNull(suggestion, "Suggestion");
-		return sugadd(key, suggestion.getString(), suggestion.getScore(), suggestion.getPayload(), false);
-	}
+    public Command<K, V, Long> sugadd(K key, V string, double score, V payload) {
+        return sugadd(key, string, score, payload, false);
+    }
 
-	public Command<K, V, Long> sugaddIncr(K key, Suggestion<V> suggestion) {
-		notNull(suggestion, "Suggestion");
-		return sugadd(key, suggestion.getString(), suggestion.getScore(), suggestion.getPayload(), true);
-	}
+    public Command<K, V, Long> sugaddIncr(K key, V string, double score, V payload) {
+        return sugadd(key, string, score, payload, true);
+    }
 
-	public Command<K, V, List<Suggestion<V>>> sugget(K key, V prefix) {
-		return sugget(key, prefix, null);
-	}
+    public Command<K, V, Long> sugadd(K key, V string, double score, V payload, boolean increment) {
+        notNullKey(key);
+        notNull(string, "String");
+        SearchCommandArgs<K, V> args = args(key);
+        args.addValue(string);
+        args.add(score);
+        if (increment) {
+            args.add(SearchCommandKeyword.INCR);
+        }
+        if (payload != null) {
+            args.add(SearchCommandKeyword.PAYLOAD);
+            args.addValue(payload);
+        }
+        return createCommand(SearchCommandType.SUGADD, new IntegerOutput<>(codec), args);
+    }
 
-	public Command<K, V, List<Suggestion<V>>> sugget(K key, V prefix, SuggetOptions options) {
-		notNullKey(key);
-		notNull(prefix, "Prefix");
-		SearchCommandArgs<K, V> args = args(key);
-		args.addValue(prefix);
-		if (options != null) {
-			options.build(args);
-		}
-		return createCommand(SearchCommandType.SUGGET, suggetOutput(options), args);
-	}
+    public Command<K, V, Long> sugadd(K key, Suggestion<V> suggestion) {
+        notNull(suggestion, "Suggestion");
+        return sugadd(key, suggestion.getString(), suggestion.getScore(), suggestion.getPayload(), false);
+    }
 
-	private SuggetOutput<K, V> suggetOutput(SuggetOptions options) {
-		if (options == null) {
-			return new SuggetOutput<>(codec);
-		}
-		return new SuggetOutput<>(codec, options.isWithScores(), options.isWithPayloads());
-	}
+    public Command<K, V, Long> sugaddIncr(K key, Suggestion<V> suggestion) {
+        notNull(suggestion, "Suggestion");
+        return sugadd(key, suggestion.getString(), suggestion.getScore(), suggestion.getPayload(), true);
+    }
 
-	public Command<K, V, Boolean> sugdel(K key, V string) {
-		notNullKey(key);
-		notNull(string, "String");
-		return createCommand(SearchCommandType.SUGDEL, new BooleanOutput<>(codec), args(key).addValue(string));
-	}
+    public Command<K, V, List<Suggestion<V>>> sugget(K key, V prefix) {
+        return sugget(key, prefix, null);
+    }
 
-	public Command<K, V, Long> suglen(K key) {
-		notNullKey(key);
-		return createCommand(SearchCommandType.SUGLEN, new IntegerOutput<>(codec), args(key));
+    public Command<K, V, List<Suggestion<V>>> sugget(K key, V prefix, SuggetOptions options) {
+        notNullKey(key);
+        notNull(prefix, "Prefix");
+        SearchCommandArgs<K, V> args = args(key);
+        args.addValue(prefix);
+        if (options != null) {
+            options.build(args);
+        }
+        return createCommand(SearchCommandType.SUGGET, suggetOutput(options), args);
+    }
 
-	}
+    private SuggetOutput<K, V> suggetOutput(SuggetOptions options) {
+        if (options == null) {
+            return new SuggetOutput<>(codec);
+        }
+        return new SuggetOutput<>(codec, options.isWithScores(), options.isWithPayloads());
+    }
 
-	private static void notNullName(Object name) {
-		notNull(name, "Name");
-	}
+    public Command<K, V, Boolean> sugdel(K key, V string) {
+        notNullKey(key);
+        notNull(string, "String");
+        return createCommand(SearchCommandType.SUGDEL, new BooleanOutput<>(codec), args(key).addValue(string));
+    }
 
-	public Command<K, V, String> aliasAdd(K name, K index) {
-		notNullName(name);
-		notNullIndex(index);
-		return createCommand(SearchCommandType.ALIASADD, new StatusOutput<>(codec), args(name).addKey(index));
-	}
+    public Command<K, V, Long> suglen(K key) {
+        notNullKey(key);
+        return createCommand(SearchCommandType.SUGLEN, new IntegerOutput<>(codec), args(key));
 
-	public Command<K, V, String> aliasUpdate(K name, K index) {
-		notNullName(name);
-		notNullIndex(index);
-		return createCommand(SearchCommandType.ALIASUPDATE, new StatusOutput<>(codec), args(name).addKey(index));
-	}
+    }
 
-	public Command<K, V, String> aliasDel(K name) {
-		notNullName(name);
-		return createCommand(SearchCommandType.ALIASDEL, new StatusOutput<>(codec), args(name));
-	}
+    private static void notNullName(Object name) {
+        notNull(name, "Name");
+    }
 
-	public Command<K, V, List<K>> list() {
-		return new Command<>(SearchCommandType.LIST, new KeyListOutput<>(codec));
-	}
+    public Command<K, V, String> aliasAdd(K name, K index) {
+        notNullName(name);
+        notNullIndex(index);
+        return createCommand(SearchCommandType.ALIASADD, new StatusOutput<>(codec), args(name).addKey(index));
+    }
+
+    public Command<K, V, String> aliasUpdate(K name, K index) {
+        notNullName(name);
+        notNullIndex(index);
+        return createCommand(SearchCommandType.ALIASUPDATE, new StatusOutput<>(codec), args(name).addKey(index));
+    }
+
+    public Command<K, V, String> aliasDel(K name) {
+        notNullName(name);
+        return createCommand(SearchCommandType.ALIASDEL, new StatusOutput<>(codec), args(name));
+    }
+
+    public Command<K, V, List<K>> list() {
+        return new Command<>(SearchCommandType.LIST, new KeyListOutput<>(codec));
+    }
 
 }


### PR DESCRIPTION
 Summary

  - Enhanced FT.SEARCH and FT.AGGREGATE commands to accept string-based options alongside existing object-based options
  - Added string parameter overloads to search and aggregate methods across sync, async, and reactive APIs
  - Updated command builders to support both option types for improved flexibility

  Changes

  - Core APIs: Added string option variants to RediSearchCommands, RediSearchAsyncCommands, and RediSearchReactiveCommands
  - Implementations: Updated command implementations in RedisModulesAsyncCommandsImpl, RedisModulesReactiveCommandsImpl, and cluster variants
  - Command Builder: Enhanced SearchCommandBuilder to handle string-based options
  - Tests: Added test coverage for new string option functionality

  Test plan

  - Verify existing tests pass with new string option support
  - Add tests for string-based search and aggregate operations
  - Validate both object and string options work correctly
  - Test across sync, async, and reactive command variants
